### PR TITLE
fix: recordZoneId 기준 now 전달로 활성 세션 음수 방지

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/studysession/StudySessionJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/studysession/StudySessionJpaRepository.java
@@ -45,7 +45,7 @@ public interface StudySessionJpaRepository extends JpaRepository<StudySessionJpa
     @Query(value = """
         select coalesce(sum(
             extract(epoch from (
-                least(coalesce(s.ended_at, current_timestamp), cast(:endOfDay as timestamp)) -
+                least(coalesce(s.ended_at, cast(:now as timestamp)), cast(:endOfDay as timestamp)) -
                 greatest(s.started_at, cast(:startOfDay as timestamp))
             ))
         ), 0)
@@ -57,14 +57,15 @@ public interface StudySessionJpaRepository extends JpaRepository<StudySessionJpa
     Long getTotalStudyTimeInSeconds(
             @Param("userId") Long userId,
             @Param("startOfDay") LocalDateTime startOfDay,
-            @Param("endOfDay") LocalDateTime endOfDay
+            @Param("endOfDay") LocalDateTime endOfDay,
+            @Param("now") LocalDateTime now
     );
 
     @Query(value = """
         select s.fk_user_id as userId,
                coalesce(sum(
                    extract(epoch from (
-                       least(coalesce(s.ended_at, current_timestamp), cast(:endOfDay as timestamp)) -
+                       least(coalesce(s.ended_at, cast(:now as timestamp)), cast(:endOfDay as timestamp)) -
                        greatest(s.started_at, cast(:startOfDay as timestamp))
                    ))
                ), 0) as totalSeconds
@@ -77,7 +78,8 @@ public interface StudySessionJpaRepository extends JpaRepository<StudySessionJpa
     List<UserStudyTimeProjection> getTotalStudyTimeInSecondsByUserIds(
             @Param("userIds") List<Long> userIds,
             @Param("startOfDay") LocalDateTime startOfDay,
-            @Param("endOfDay") LocalDateTime endOfDay
+            @Param("endOfDay") LocalDateTime endOfDay,
+            @Param("now") LocalDateTime now
     );
 
     interface UserStudyTimeProjection {

--- a/src/main/java/com/process/clash/adapter/persistence/studysession/StudySessionPersistenceAdapter.java
+++ b/src/main/java/com/process/clash/adapter/persistence/studysession/StudySessionPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.process.clash.application.record.exception.exception.notfound.StudySe
 import com.process.clash.application.record.port.out.StudySessionRepositoryPort;
 import com.process.clash.domain.record.entity.StudySession;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ public class StudySessionPersistenceAdapter implements StudySessionRepositoryPor
     private final StudySessionJpaMapper studySessionJpaMapper;
     private final UserJpaRepository userJpaRepository;
     private final TaskJpaRepository taskJpaRepository;
+    private final ZoneId recordZoneId;
 
     @Override
     public StudySession save(StudySession studySession) {
@@ -134,7 +136,8 @@ public class StudySessionPersistenceAdapter implements StudySessionRepositoryPor
 
     @Override
     public Long getTotalStudyTimeInSeconds(Long userId, LocalDateTime startOfDay, LocalDateTime endOfDay) {
-        return studySessionJpaRepository.getTotalStudyTimeInSeconds(userId, startOfDay, endOfDay);
+        LocalDateTime now = LocalDateTime.now(recordZoneId);
+        return studySessionJpaRepository.getTotalStudyTimeInSeconds(userId, startOfDay, endOfDay, now);
     }
 
     @Override
@@ -147,8 +150,9 @@ public class StudySessionPersistenceAdapter implements StudySessionRepositoryPor
             return Map.of();
         }
 
+        LocalDateTime now = LocalDateTime.now(recordZoneId);
         return studySessionJpaRepository
-                .getTotalStudyTimeInSecondsByUserIds(userIds, startTime, endTime)
+                .getTotalStudyTimeInSecondsByUserIds(userIds, startTime, endTime, now)
                 .stream()
                 .collect(Collectors.toMap(
                         StudySessionJpaRepository.UserStudyTimeProjection::getUserId,

--- a/src/test/java/com/process/clash/adapter/persistence/studysession/StudySessionPersistenceAdapterTest.java
+++ b/src/test/java/com/process/clash/adapter/persistence/studysession/StudySessionPersistenceAdapterTest.java
@@ -1,0 +1,108 @@
+package com.process.clash.adapter.persistence.studysession;
+
+import com.process.clash.adapter.persistence.task.TaskJpaRepository;
+import com.process.clash.adapter.persistence.user.user.UserJpaRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StudySessionPersistenceAdapterTest {
+
+    private static final ZoneId RECORD_ZONE_ID = ZoneId.of("UTC");
+
+    @Mock
+    private StudySessionJpaRepository studySessionJpaRepository;
+
+    @Mock
+    private StudySessionJpaMapper studySessionJpaMapper;
+
+    @Mock
+    private UserJpaRepository userJpaRepository;
+
+    @Mock
+    private TaskJpaRepository taskJpaRepository;
+
+    private StudySessionPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new StudySessionPersistenceAdapter(
+            studySessionJpaRepository,
+            studySessionJpaMapper,
+            userJpaRepository,
+            taskJpaRepository,
+            RECORD_ZONE_ID
+        );
+    }
+
+    @Test
+    @DisplayName("단일 사용자 합산 조회 시 recordZoneId 기준 now를 전달한다")
+    void getTotalStudyTimeInSeconds_passesRecordZoneNow() {
+        LocalDateTime startOfDay = LocalDateTime.of(2026, 1, 1, 6, 0);
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        when(studySessionJpaRepository.getTotalStudyTimeInSeconds(anyLong(), any(), any(), any()))
+            .thenReturn(120L);
+
+        LocalDateTime before = LocalDateTime.now(RECORD_ZONE_ID);
+        adapter.getTotalStudyTimeInSeconds(1L, startOfDay, endOfDay);
+        LocalDateTime after = LocalDateTime.now(RECORD_ZONE_ID);
+
+        ArgumentCaptor<LocalDateTime> nowCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(studySessionJpaRepository)
+            .getTotalStudyTimeInSeconds(eq(1L), eq(startOfDay), eq(endOfDay), nowCaptor.capture());
+
+        LocalDateTime nowArg = nowCaptor.getValue();
+        assertThat(nowArg).isAfterOrEqualTo(before);
+        assertThat(nowArg).isBeforeOrEqualTo(after);
+    }
+
+    @Test
+    @DisplayName("복수 사용자 합산 조회 시 recordZoneId 기준 now를 전달한다")
+    void getTotalStudyTimeInSecondsByUserIds_passesRecordZoneNow() {
+        LocalDateTime startOfDay = LocalDateTime.of(2026, 1, 1, 6, 0);
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        List<Long> userIds = List.of(1L, 2L);
+        when(studySessionJpaRepository.getTotalStudyTimeInSecondsByUserIds(any(), any(), any(), any()))
+            .thenReturn(List.of());
+
+        LocalDateTime before = LocalDateTime.now(RECORD_ZONE_ID);
+        adapter.getTotalStudyTimeInSecondsByUserIds(userIds, startOfDay, endOfDay);
+        LocalDateTime after = LocalDateTime.now(RECORD_ZONE_ID);
+
+        ArgumentCaptor<LocalDateTime> nowCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(studySessionJpaRepository)
+            .getTotalStudyTimeInSecondsByUserIds(eq(userIds), eq(startOfDay), eq(endOfDay), nowCaptor.capture());
+
+        LocalDateTime nowArg = nowCaptor.getValue();
+        assertThat(nowArg).isAfterOrEqualTo(before);
+        assertThat(nowArg).isBeforeOrEqualTo(after);
+    }
+
+    @Test
+    @DisplayName("복수 사용자 합산 조회 시 ID가 비어있으면 쿼리를 호출하지 않는다")
+    void getTotalStudyTimeInSecondsByUserIds_skipsWhenEmpty() {
+        LocalDateTime startOfDay = LocalDateTime.of(2026, 1, 1, 6, 0);
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        adapter.getTotalStudyTimeInSecondsByUserIds(List.of(), startOfDay, endOfDay);
+
+        verify(studySessionJpaRepository, never())
+            .getTotalStudyTimeInSecondsByUserIds(any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
일전 GetAllTasks 시 TimeZone 통일 문제를 group 도메인에서도 수정
- 핫픽스