### PR TITLE
fix: AuthUser가 아닌 principal(String 등)은 Rate Limit 없이 그냥 통과, 캐스팅 에러 제거

### DIFF
--- a/src/main/java/com/process/clash/infrastructure/filter/RateLimitFilter.java
+++ b/src/main/java/com/process/clash/infrastructure/filter/RateLimitFilter.java
@@ -74,7 +74,12 @@ public class RateLimitFilter extends GenericFilterBean {
         }
 
         // 3. User 정보 추출
-        AuthUser userDetails = (AuthUser) authentication.getPrincipal();
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof AuthUser)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        AuthUser userDetails = (AuthUser) principal;
         Long userId = userDetails.id();
         boolean isAdmin = userDetails.role().equals(Role.ADMIN);
 


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- AuthUser가 아닌 principal(String 등)은 Rate Limit 없이 그냥 통과, 캐스팅 에러 제거

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #

## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
