### PR TITLE
feat: session-life-cycle/#449

### DIFF
--- a/src/main/java/com/process/clash/application/record/v2/realtime/RecordV2PresenceStatusChangedNotifier.java
+++ b/src/main/java/com/process/clash/application/record/v2/realtime/RecordV2PresenceStatusChangedNotifier.java
@@ -35,15 +35,15 @@ public class RecordV2PresenceStatusChangedNotifier implements NotifyPresenceStat
         if (userId == null || previousStatus == null || currentStatus == null) {
             return;
         }
-        if (!shouldStopActiveSession(previousStatus, currentStatus)) {
+        if (!isSessionStoppingTransition(previousStatus, currentStatus)) {
             return;
         }
 
         recordSessionV2RepositoryPort.findActiveSessionByUserIdForUpdate(userId)
-            .ifPresent(this::stopActiveSession);
+            .ifPresent(activeSession -> stopActiveSessionIfNeeded(activeSession, currentStatus));
     }
 
-    private boolean shouldStopActiveSession(
+    private boolean isSessionStoppingTransition(
         UserActivityStatus previousStatus,
         UserActivityStatus currentStatus
     ) {
@@ -51,11 +51,17 @@ public class RecordV2PresenceStatusChangedNotifier implements NotifyPresenceStat
             return false;
         }
 
-        // 자리비움/오프라인 전환 시 진행 중인 기록 세션은 유지되면 안 된다.
         return currentStatus == UserActivityStatus.AWAY || currentStatus == UserActivityStatus.OFFLINE;
     }
 
-    private void stopActiveSession(RecordSessionV2 activeSession) {
+    private void stopActiveSessionIfNeeded(
+        RecordSessionV2 activeSession,
+        UserActivityStatus currentStatus
+    ) {
+        if (currentStatus == UserActivityStatus.AWAY && activeSession.sessionType() == RecordSessionTypeV2.TASK) {
+            return;
+        }
+
         Instant endedAt = Instant.now();
         if (activeSession.sessionType() == RecordSessionTypeV2.DEVELOP) {
             recordDevelopSessionSegmentV2RepositoryPort.findOpenSegmentBySessionIdForUpdate(activeSession.id())

--- a/src/main/java/com/process/clash/application/record/v2/service/StartRecordV2Service.java
+++ b/src/main/java/com/process/clash/application/record/v2/service/StartRecordV2Service.java
@@ -159,14 +159,17 @@ public class StartRecordV2Service implements StartRecordV2UseCase {
             return;
         }
 
-        if (userPresencePort.getStatus(userId) == UserActivityStatus.ONLINE) {
+        UserActivityStatus activityStatus = userPresencePort.getStatus(userId);
+
+        if (sessionType == RecordSessionTypeV2.DEVELOP) {
+            if (activityStatus != UserActivityStatus.ONLINE) {
+                throw new DevelopStartRequiresOnlineException();
+            }
             return;
         }
 
-        if (sessionType == RecordSessionTypeV2.DEVELOP) {
-            throw new DevelopStartRequiresOnlineException();
+        if (activityStatus != UserActivityStatus.ONLINE) {
+            throw new TaskStartRequiresOnlineException();
         }
-
-        throw new TaskStartRequiresOnlineException();
     }
 }

--- a/src/test/java/com/process/clash/application/record/v2/realtime/RecordV2PresenceFlowIntegrationTest.java
+++ b/src/test/java/com/process/clash/application/record/v2/realtime/RecordV2PresenceFlowIntegrationTest.java
@@ -68,6 +68,30 @@ class RecordV2PresenceFlowIntegrationTest {
     }
 
     @Test
+    @DisplayName("presence:away 수신 시 진행 중인 TASK 세션은 유지된다")
+    void awayEvent_keepsTaskSession() {
+        User user = createActiveUser();
+        String connectionId = "conn-task-away-v2-" + UUID.randomUUID();
+        Actor actor = new Actor(user.id());
+        RecordSubjectV2 subject = createSubject(user.id(), "알고리즘");
+
+        reportUserPresenceUseCase.connected(connectionId, user.id());
+        startRecordV2UseCase.execute(new StartRecordV2Data.Command(
+            RecordSessionTypeV2.TASK,
+            subject.id(),
+            null,
+            null,
+            actor
+        ));
+        assertThat(recordSessionV2RepositoryPort.findActiveSessionByUserId(user.id())).isPresent();
+
+        reportUserPresenceUseCase.markedAway(connectionId);
+
+        assertThat(recordSessionV2RepositoryPort.findActiveSessionByUserId(user.id())).isPresent();
+        reportUserPresenceUseCase.disconnected(connectionId);
+    }
+
+    @Test
     @DisplayName("소켓 연결 종료 시 진행 중인 DEVELOP 세션이 종료된다")
     void disconnect_stopsDevelopSession() {
         User user = createActiveUser();
@@ -113,8 +137,8 @@ class RecordV2PresenceFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 자리비움/오프라인이면 DEVELOP 세션을 시작할 수 없다")
-    void cannotStartDevelopWhenNotOnline() {
+    @DisplayName("자리비움이면 DEVELOP 세션을 시작할 수 없다")
+    void cannotStartDevelopWhenAway() {
         User user = createActiveUser();
         String connectionId = "conn-start-while-away-v2-" + UUID.randomUUID();
         Actor actor = new Actor(user.id());
@@ -136,8 +160,45 @@ class RecordV2PresenceFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 자리비움/오프라인이면 TASK 세션을 시작할 수 없다")
-    void cannotStartTaskWhenNotOnline() {
+    @DisplayName("오프라인이면 DEVELOP 세션을 시작할 수 없다")
+    void cannotStartDevelopWhenOffline() {
+        User user = createActiveUser();
+        Actor actor = new Actor(user.id());
+
+        assertThatThrownBy(() -> startRecordV2UseCase.execute(new StartRecordV2Data.Command(
+            RecordSessionTypeV2.DEVELOP,
+            null,
+            null,
+            MonitoredApp.VSCODE,
+            actor
+        )))
+            .isInstanceOf(DevelopStartRequiresOnlineException.class);
+
+        assertThat(recordSessionV2RepositoryPort.findActiveSessionByUserId(user.id())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("오프라인이면 TASK 세션을 시작할 수 없다")
+    void cannotStartTaskWhenOffline() {
+        User user = createActiveUser();
+        Actor actor = new Actor(user.id());
+        RecordSubjectV2 subject = createSubject(user.id(), "운영체제");
+
+        assertThatThrownBy(() -> startRecordV2UseCase.execute(new StartRecordV2Data.Command(
+            RecordSessionTypeV2.TASK,
+            subject.id(),
+            null,
+            null,
+            actor
+        )))
+            .isInstanceOf(TaskStartRequiresOnlineException.class);
+
+        assertThat(recordSessionV2RepositoryPort.findActiveSessionByUserId(user.id())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("자리비움이면 TASK 세션을 시작할 수 없다")
+    void cannotStartTaskWhenAway() {
         User user = createActiveUser();
         String connectionId = "conn-task-start-while-away-v2-" + UUID.randomUUID();
         Actor actor = new Actor(user.id());

--- a/src/test/java/com/process/clash/application/record/v2/realtime/RecordV2PresenceStatusChangedNotifierTest.java
+++ b/src/test/java/com/process/clash/application/record/v2/realtime/RecordV2PresenceStatusChangedNotifierTest.java
@@ -100,8 +100,36 @@ class RecordV2PresenceStatusChangedNotifierTest {
     }
 
     @Test
-    @DisplayName("자리비움/오프라인 전환 시 TASK 세션도 자동 종료한다")
-    void notifyStatusChanged_stopsTaskSession() {
+    @DisplayName("자리비움 전환 시 TASK 세션은 유지한다")
+    void notifyStatusChanged_keepsTaskSessionWhenAway() {
+        Long userId = 1L;
+        RecordSessionV2 taskSession = new RecordSessionV2(
+            200L,
+            userId,
+            RecordSessionTypeV2.TASK,
+            10L,
+            "자료구조",
+            null,
+            null,
+            null,
+            Instant.now().minusSeconds(120),
+            null
+        );
+
+        when(recordSessionV2RepositoryPort.findActiveSessionByUserIdForUpdate(userId))
+            .thenReturn(Optional.of(taskSession));
+
+        notifier.notifyStatusChanged(userId, UserActivityStatus.ONLINE, UserActivityStatus.AWAY);
+
+        verify(recordSessionV2RepositoryPort, never()).save(any(RecordSessionV2.class));
+        verify(recordDevelopSessionSegmentV2RepositoryPort, never()).findOpenSegmentBySessionIdForUpdate(any());
+        verify(recordActivityNotifierPort, never()).notifyActivityStopped(any());
+        verify(studyTimeExpGrantService, never()).grant(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("오프라인 전환 시 TASK 세션은 자동 종료한다")
+    void notifyStatusChanged_stopsTaskSessionWhenOffline() {
         Long userId = 1L;
         RecordSessionV2 taskSession = new RecordSessionV2(
             200L,

--- a/src/test/java/com/process/clash/application/record/v2/service/StartRecordV2ServiceTest.java
+++ b/src/test/java/com/process/clash/application/record/v2/service/StartRecordV2ServiceTest.java
@@ -324,8 +324,8 @@ class StartRecordV2ServiceTest {
     }
 
     @Test
-    @DisplayName("DEVELOP 세션 시작 시 유저 상태가 ONLINE이 아니면 예외가 발생한다")
-    void execute_throwsWhenDevelopStartAndStatusIsNotOnline() {
+    @DisplayName("DEVELOP 세션은 AWAY 상태에서 시작할 수 없다")
+    void execute_throwsWhenDevelopStartAndStatusIsAway() {
         Actor actor = new Actor(1L);
         User user = createUser(1L);
         StartRecordV2Data.Command command = new StartRecordV2Data.Command(
@@ -349,8 +349,58 @@ class StartRecordV2ServiceTest {
     }
 
     @Test
-    @DisplayName("TASK 세션 시작 시 유저 상태가 ONLINE이 아니면 예외가 발생한다")
-    void execute_throwsWhenTaskStartAndStatusIsNotOnline() {
+    @DisplayName("DEVELOP 세션은 OFFLINE 상태에서 시작할 수 없다")
+    void execute_throwsWhenDevelopStartAndStatusIsOffline() {
+        Actor actor = new Actor(1L);
+        User user = createUser(1L);
+        StartRecordV2Data.Command command = new StartRecordV2Data.Command(
+            RecordSessionTypeV2.DEVELOP,
+            null,
+            null,
+            MonitoredApp.VSCODE,
+            actor
+        );
+
+        when(userRepositoryPort.findById(actor.id())).thenReturn(Optional.of(user));
+        when(recordSessionV2RepositoryPort.existsActiveSessionByUserId(actor.id())).thenReturn(false);
+        when(userPresencePort.getStatus(actor.id())).thenReturn(UserActivityStatus.OFFLINE);
+
+        assertThatThrownBy(() -> startRecordV2Service.execute(command))
+            .isInstanceOf(DevelopStartRequiresOnlineException.class);
+
+        verify(recordSessionV2RepositoryPort, never()).save(any(RecordSessionV2.class));
+        verify(recordDevelopSessionSegmentV2RepositoryPort, never()).save(any());
+        verify(recordActivityNotifierPort, never()).notifyActivityStarted(any());
+    }
+
+    @Test
+    @DisplayName("TASK 세션은 AWAY 상태에서 시작할 수 없다")
+    void execute_throwsWhenTaskStartAndStatusIsAway() {
+        Actor actor = new Actor(1L);
+        User user = createUser(1L);
+        StartRecordV2Data.Command command = new StartRecordV2Data.Command(
+            RecordSessionTypeV2.TASK,
+            10L,
+            null,
+            null,
+            actor
+        );
+
+        when(userRepositoryPort.findById(actor.id())).thenReturn(Optional.of(user));
+        when(recordSessionV2RepositoryPort.existsActiveSessionByUserId(actor.id())).thenReturn(false);
+        when(userPresencePort.getStatus(actor.id())).thenReturn(UserActivityStatus.AWAY);
+
+        assertThatThrownBy(() -> startRecordV2Service.execute(command))
+            .isInstanceOf(TaskStartRequiresOnlineException.class);
+
+        verify(recordSessionV2RepositoryPort, never()).save(any(RecordSessionV2.class));
+        verify(recordDevelopSessionSegmentV2RepositoryPort, never()).save(any());
+        verify(recordActivityNotifierPort, never()).notifyActivityStarted(any());
+    }
+
+    @Test
+    @DisplayName("TASK 세션은 OFFLINE 상태에서 시작할 수 없다")
+    void execute_throwsWhenTaskStartAndStatusIsOffline() {
         Actor actor = new Actor(1L);
         User user = createUser(1L);
         StartRecordV2Data.Command command = new StartRecordV2Data.Command(


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- `Record v2`의 presence 기반 세션 종료 규칙을 요구사항에 맞게 조정했습니다.
- `AWAY` 상태에서는 `DEVELOP` 세션만 종료되고 `TASK` 세션은 유지되도록 수정했습니다.
- `OFFLINE` 상태에서는 `DEVELOP`/`TASK` 세션이 모두 종료되도록 정리했습니다.
- 세션 시작 조건도 정리해 `DEVELOP`/`TASK` 모두 `AWAY`/`OFFLINE` 상태에서는 시작할 수 없도록 수정했습니다.
- 관련 unit test 및 integration test를 보강해 `AWAY`/`OFFLINE`별 세션 종료/시작 규칙을 검증했습니다.

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #449

## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->

- 서버가 직접 5분 idle 시간을 계산하는 구조는 아니고, presence가 `AWAY`로 전환되었을 때 해당 규칙이 적용되는 구조입니다.
- `TASK_START_REQUIRES_ONLINE` 예외 코드는 유지했고, 실제 정책과 맞도록 테스트 기대값을 함께 정리했습니다.