### PR TITLE
fix: zero score ranking bug/#458

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/github/GitHubDailyStatsJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/github/GitHubDailyStatsJpaRepository.java
@@ -207,7 +207,7 @@ public interface GitHubDailyStatsJpaRepository extends JpaRepository<GitHubDaily
                 or (r.secondUser.id = ug.user.id and r.firstUser.id = :userId))
             and r.rivalLinkingStatus = 'ACCEPTED'
         group by ug.user.id, ug.user.name, ug.user.profileImage, ug.user.username, ug.gitHubId
-        order by sum(g.commitCount + g.issueCount + g.prCount + g.reviewCount) desc
+        order by sum(g.commitCount + g.issueCount + g.prCount + g.reviewCount) desc nulls last
     """)
     List<UserRanking> findGitHubRankingByUserIdAndPeriod(
             @Param("userId") Long userId,


### PR DESCRIPTION
## 변경사항
- `findGitHubRankingByUserIdAndPeriod` 쿼리의 ORDER BY에 `nulls last` 추가

## 관련 이슈
Closes #458

## 추가 컨텍스트
GitHub 계정은 연동했지만 해당 기간에 활동(커밋/PR/이슈/리뷰)이 없는 유저의 경우
LEFT JOIN 결과 sum이 NULL이 됨.
PostgreSQL에서 `ORDER BY ... DESC`는 기본적으로 NULLS FIRST로 동작하여
활동이 없는 유저(0점)가 랭킹 1위에 올라오는 버그 발생.
`nulls last`를 명시하여 NULL이 항상 마지막에 오도록 수정.
