### PR TITLE
fix: group-activity-negative-study-time/#543

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/record/v2/session/RecordActiveSessionV2JpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/record/v2/session/RecordActiveSessionV2JpaRepository.java
@@ -140,10 +140,12 @@ public interface RecordActiveSessionV2JpaRepository extends JpaRepository<Record
     @Query(value = """
         select s.fk_user_id as userId,
                coalesce(sum(
-                   extract(epoch from (
+                GREATEST(0,
+                       extract(epoch from (
                        least(coalesce(s.ended_at, :now), :endOfDay) -
                        greatest(s.started_at, :startOfDay)
                    ))
+                )
                ), 0) as totalSeconds
         from record_active_sessions_v2 s
         where s.fk_user_id IN :userIds


### PR DESCRIPTION
## 변경사항
- 그룹원 활동 조회 시 현재 공부 중인 사람의 다음날 기록을 조회하면 학습 시간이 음수로 반환되는 버그 수정
- `getTotalStudyTimeInSecondsByUserIds` 쿼리에 `GREATEST(0, ...)` 추가하여 음수 반환 방지

## 관련 이슈
Closes #543

## 추가 컨텍스트
- 진행 중인 세션(`ended_at = null`)을 다음날 윈도우로 조회할 경우, `least(coalesce(ended_at, now), endOfDay)`가 현재 시각을 반환하고 `greatest(started_at, startOfDay)`가 다음날 시작 시각을 반환해 결과값이 음수가 되는 구조적 문제
- SQL 레벨에서 `GREATEST(0, extract(epoch from (...)))` 로 감싸 음수 발생 시 0으로 처리
