### PR TITLE
fix: record-todo-constraint/#547

### DIFF
--- a/src/main/java/com/process/clash/application/record/v2/service/StartRecordV2Service.java
+++ b/src/main/java/com/process/clash/application/record/v2/service/StartRecordV2Service.java
@@ -112,6 +112,7 @@ public class StartRecordV2Service implements StartRecordV2UseCase {
             if (command.taskId() != null) {
                 task = recordTaskV2RepositoryPort.findByIdAndUserId(command.taskId(), command.actor().id())
                     .orElseThrow(TaskV2NotFoundException::new);
+                validateTaskNotCompleted(task);
                 validateTaskRecordDate(task);
             }
 
@@ -158,6 +159,12 @@ public class StartRecordV2Service implements StartRecordV2UseCase {
     private void validateTaskRecordDate(RecordTaskV2 task) {
         LocalDate todayRecordDate = RecordDayWindow.today(recordZoneId, recordProperties.dayBoundaryHour()).recordDate();
         if (!task.belongsToRecordDate(todayRecordDate)) {
+            throw new InvalidRecordV2StartRequestException();
+        }
+    }
+
+    private void validateTaskNotCompleted(RecordTaskV2 task) {
+        if (task.completed()) {
             throw new InvalidRecordV2StartRequestException();
         }
     }

--- a/src/main/java/com/process/clash/application/record/v2/service/UpdateTaskCompletionV2Service.java
+++ b/src/main/java/com/process/clash/application/record/v2/service/UpdateTaskCompletionV2Service.java
@@ -1,27 +1,67 @@
 package com.process.clash.application.record.v2.service;
 
+import com.process.clash.application.common.actor.Actor;
 import com.process.clash.application.record.v2.data.UpdateTaskCompletionV2Data;
 import com.process.clash.application.record.v2.exception.exception.notfound.TaskV2NotFoundException;
 import com.process.clash.application.record.v2.port.in.UpdateTaskCompletionV2UseCase;
+import com.process.clash.application.record.v2.port.out.RecordActivityNotifierPort;
+import com.process.clash.application.record.v2.port.out.RecordDevelopSessionSegmentV2RepositoryPort;
+import com.process.clash.application.record.v2.port.out.RecordSessionV2RepositoryPort;
 import com.process.clash.application.record.v2.port.out.RecordTaskV2RepositoryPort;
+import com.process.clash.application.user.exp.service.StudyTimeExpGrantService;
+import com.process.clash.domain.record.v2.entity.RecordSessionV2;
 import com.process.clash.domain.record.v2.entity.RecordTaskV2;
+import com.process.clash.domain.record.v2.enums.RecordSessionTypeV2;
 import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class UpdateTaskCompletionV2Service implements UpdateTaskCompletionV2UseCase {
 
     private final RecordTaskV2RepositoryPort recordTaskV2RepositoryPort;
+    private final RecordSessionV2RepositoryPort recordSessionV2RepositoryPort;
+    private final RecordDevelopSessionSegmentV2RepositoryPort recordDevelopSessionSegmentV2RepositoryPort;
+    private final RecordActivityNotifierPort recordActivityNotifierPort;
+    private final StudyTimeExpGrantService studyTimeExpGrantService;
 
     @Override
     public UpdateTaskCompletionV2Data.Result execute(UpdateTaskCompletionV2Data.Command command) {
         RecordTaskV2 task = recordTaskV2RepositoryPort.findByIdAndUserId(command.taskId(), command.actor().id())
             .orElseThrow(TaskV2NotFoundException::new);
         RecordTaskV2 savedTask = recordTaskV2RepositoryPort.save(task.changeCompleted(command.completed()));
+        if (command.completed()) {
+            stopActiveTaskSessionIfNeeded(command.actor(), task.id());
+        }
 
         return UpdateTaskCompletionV2Data.Result.from(savedTask);
+    }
+
+    private void stopActiveTaskSessionIfNeeded(Actor actor, Long taskId) {
+        recordSessionV2RepositoryPort.findActiveSessionByUserIdForUpdate(actor.id())
+            .filter(activeSession -> Objects.equals(activeSession.taskId(), taskId))
+            .ifPresent(activeSession -> stopActiveSession(activeSession, actor));
+    }
+
+    private void stopActiveSession(RecordSessionV2 activeSession, Actor actor) {
+        Instant endedAt = Instant.now();
+        if (activeSession.sessionType() == RecordSessionTypeV2.DEVELOP) {
+            recordDevelopSessionSegmentV2RepositoryPort.findOpenSegmentBySessionIdForUpdate(activeSession.id())
+                .ifPresent(segment -> recordDevelopSessionSegmentV2RepositoryPort.save(segment.changeEndedAt(endedAt)));
+        }
+
+        recordSessionV2RepositoryPort.save(activeSession.changeEndedAt(endedAt));
+        recordActivityNotifierPort.notifyActivityStopped(actor);
+        try {
+            studyTimeExpGrantService.grant(activeSession.userId(), activeSession.startedAt(), endedAt);
+        } catch (Exception e) {
+            log.error("학습시간 EXP 지급 실패 (task completion auto stop). userId={}", activeSession.userId(), e);
+        }
     }
 }

--- a/src/test/java/com/process/clash/application/record/v2/service/StartRecordV2ServiceTest.java
+++ b/src/test/java/com/process/clash/application/record/v2/service/StartRecordV2ServiceTest.java
@@ -331,6 +331,41 @@ class StartRecordV2ServiceTest {
     }
 
     @Test
+    @DisplayName("완료된 task로는 TASK 세션을 시작할 수 없다")
+    void execute_throwsWhenTaskAlreadyCompleted() {
+        Actor actor = new Actor(1L);
+        User user = createUser(1L);
+        RecordTaskV2 task = new RecordTaskV2(
+            11L,
+            1L,
+            null,
+            "해시테이블",
+            true,
+            0L,
+            currentRecordDate(),
+            Instant.now(),
+            Instant.now()
+        );
+        StartRecordV2Data.Command command = new StartRecordV2Data.Command(
+            RecordSessionTypeV2.TASK,
+            null,
+            11L,
+            null,
+            actor
+        );
+
+        when(userRepositoryPort.findById(actor.id())).thenReturn(Optional.of(user));
+        when(recordSessionV2RepositoryPort.existsActiveSessionByUserId(actor.id())).thenReturn(false);
+        when(recordTaskV2RepositoryPort.findByIdAndUserId(11L, 1L)).thenReturn(Optional.of(task));
+
+        assertThatThrownBy(() -> startRecordV2Service.execute(command))
+            .isInstanceOf(InvalidRecordV2StartRequestException.class);
+
+        verify(recordSessionV2RepositoryPort, never()).save(any(RecordSessionV2.class));
+        verify(recordActivityNotifierPort, never()).notifyActivityStarted(any());
+    }
+
+    @Test
     @DisplayName("sessionType이 null이면 요청 형태와 무관하게 예외가 발생한다")
     void execute_throwsWhenSessionTypeIsNull() {
         Actor actor = new Actor(1L);

--- a/src/test/java/com/process/clash/application/record/v2/service/UpdateTaskCompletionV2ServiceTest.java
+++ b/src/test/java/com/process/clash/application/record/v2/service/UpdateTaskCompletionV2ServiceTest.java
@@ -3,13 +3,21 @@ package com.process.clash.application.record.v2.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import com.process.clash.application.common.actor.Actor;
 import com.process.clash.application.record.v2.data.UpdateTaskCompletionV2Data;
 import com.process.clash.application.record.v2.exception.exception.notfound.TaskV2NotFoundException;
+import com.process.clash.application.record.v2.port.out.RecordActivityNotifierPort;
+import com.process.clash.application.record.v2.port.out.RecordDevelopSessionSegmentV2RepositoryPort;
+import com.process.clash.application.record.v2.port.out.RecordSessionV2RepositoryPort;
 import com.process.clash.application.record.v2.port.out.RecordTaskV2RepositoryPort;
+import com.process.clash.application.user.exp.service.StudyTimeExpGrantService;
+import com.process.clash.domain.record.v2.entity.RecordSessionV2;
 import com.process.clash.domain.record.v2.entity.RecordTaskV2;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -27,11 +35,29 @@ class UpdateTaskCompletionV2ServiceTest {
     @Mock
     private RecordTaskV2RepositoryPort recordTaskV2RepositoryPort;
 
+    @Mock
+    private RecordSessionV2RepositoryPort recordSessionV2RepositoryPort;
+
+    @Mock
+    private RecordDevelopSessionSegmentV2RepositoryPort recordDevelopSessionSegmentV2RepositoryPort;
+
+    @Mock
+    private RecordActivityNotifierPort recordActivityNotifierPort;
+
+    @Mock
+    private StudyTimeExpGrantService studyTimeExpGrantService;
+
     private UpdateTaskCompletionV2Service updateTaskCompletionV2Service;
 
     @BeforeEach
     void setUp() {
-        updateTaskCompletionV2Service = new UpdateTaskCompletionV2Service(recordTaskV2RepositoryPort);
+        updateTaskCompletionV2Service = new UpdateTaskCompletionV2Service(
+            recordTaskV2RepositoryPort,
+            recordSessionV2RepositoryPort,
+            recordDevelopSessionSegmentV2RepositoryPort,
+            recordActivityNotifierPort,
+            studyTimeExpGrantService
+        );
     }
 
     @Test
@@ -44,11 +70,71 @@ class UpdateTaskCompletionV2ServiceTest {
         when(recordTaskV2RepositoryPort.findByIdAndUserId(11L, 1L)).thenReturn(Optional.of(task));
         when(recordTaskV2RepositoryPort.save(any(RecordTaskV2.class)))
             .thenAnswer(invocation -> invocation.getArgument(0));
+        when(recordSessionV2RepositoryPort.findActiveSessionByUserIdForUpdate(1L))
+            .thenReturn(Optional.empty());
 
         UpdateTaskCompletionV2Data.Result result = updateTaskCompletionV2Service.execute(command);
 
         assertThat(result.task().completed()).isTrue();
         verify(recordTaskV2RepositoryPort).save(any(RecordTaskV2.class));
+    }
+
+    @Test
+    @DisplayName("완료 처리 시 같은 task의 진행 중 세션이 있으면 종료한다")
+    void execute_stopsActiveSessionWhenCompletingActiveTask() {
+        Actor actor = new Actor(1L);
+        Instant startedAt = Instant.now().minusSeconds(300);
+        RecordTaskV2 task = new RecordTaskV2(11L, 1L, null, "리팩터링", false, 0L, LocalDate.of(2026, 3, 16), Instant.now(), Instant.now());
+        RecordSessionV2 activeSession = new RecordSessionV2(
+            100L,
+            1L,
+            com.process.clash.domain.record.v2.enums.RecordSessionTypeV2.TASK,
+            null,
+            null,
+            11L,
+            "리팩터링",
+            null,
+            startedAt,
+            null
+        );
+        UpdateTaskCompletionV2Data.Command command = new UpdateTaskCompletionV2Data.Command(actor, 11L, true);
+
+        when(recordTaskV2RepositoryPort.findByIdAndUserId(11L, 1L)).thenReturn(Optional.of(task));
+        when(recordTaskV2RepositoryPort.save(any(RecordTaskV2.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+        when(recordSessionV2RepositoryPort.findActiveSessionByUserIdForUpdate(1L))
+            .thenReturn(Optional.of(activeSession));
+        when(recordSessionV2RepositoryPort.save(any(RecordSessionV2.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateTaskCompletionV2Data.Result result = updateTaskCompletionV2Service.execute(command);
+
+        assertThat(result.task().completed()).isTrue();
+        verify(recordSessionV2RepositoryPort).save(
+            argThat(session -> session.id().equals(100L) && session.endedAt() != null)
+        );
+        verify(recordActivityNotifierPort).notifyActivityStopped(actor);
+        verify(studyTimeExpGrantService).grant(eq(1L), eq(startedAt), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("미완료 처리이거나 다른 task 세션이면 종료하지 않는다")
+    void execute_doesNotStopSessionWhenNotCompletingActiveTask() {
+        Actor actor = new Actor(1L);
+        RecordTaskV2 task = new RecordTaskV2(11L, 1L, null, "리팩터링", true, 0L, LocalDate.of(2026, 3, 16), Instant.now(), Instant.now());
+        UpdateTaskCompletionV2Data.Command command = new UpdateTaskCompletionV2Data.Command(actor, 11L, false);
+
+        when(recordTaskV2RepositoryPort.findByIdAndUserId(11L, 1L)).thenReturn(Optional.of(task));
+        when(recordTaskV2RepositoryPort.save(any(RecordTaskV2.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateTaskCompletionV2Data.Result result = updateTaskCompletionV2Service.execute(command);
+
+        assertThat(result.task().completed()).isFalse();
+        verify(recordSessionV2RepositoryPort, never()).findActiveSessionByUserIdForUpdate(any());
+        verify(recordSessionV2RepositoryPort, never()).save(any(RecordSessionV2.class));
+        verify(recordActivityNotifierPort, never()).notifyActivityStopped(any());
+        verify(studyTimeExpGrantService, never()).grant(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 변경사항

- 완료된 `Record Task`로는 기록 세션을 시작할 수 없도록 시작 로직에 검증을 추가했습니다.
- 특정 할 일을 완료 처리할 때, 해당 할 일로 진행 중인 기록 세션이 있으면 자동으로 종료되도록 수정했습니다.
- 위 동작을 검증하는 `StartRecordV2ServiceTest`, `UpdateTaskCompletionV2ServiceTest`를 추가/보강했습니다.

## 관련 이슈

Closes #547 

## 추가 컨텍스트

- 완료된 할 일 시작 차단은 기존 예외 흐름에 맞춰 `InvalidRecordV2StartRequestException`으로 처리했습니다.
- 할 일 완료 시 세션 종료는 기존 기록 종료 흐름과 동일하게 활동 종료 알림과 학습 시간 EXP 지급까지 수행하도록 맞췄습니다.
- 검증: `./gradlew test --tests 'com.process.clash.application.record.v2.service.*'`
