### PR TITLE
fix: scheduler skip/#590

### DIFF
--- a/src/main/java/com/process/clash/adapter/scheduler/GithubStatsSyncScheduler.java
+++ b/src/main/java/com/process/clash/adapter/scheduler/GithubStatsSyncScheduler.java
@@ -5,6 +5,7 @@ import com.process.clash.application.ranking.service.ZeroRankingDataInitService;
 import com.process.clash.application.user.exp.service.GithubExpGrantService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,17 +19,27 @@ public class GithubStatsSyncScheduler {
     private final ZeroRankingDataInitService zeroRankingDataInitService;
 
     // 6시에는 365일 동기화가 작동하기에 30일 동기화는 6시를 제외한 매 시간에 작동하도록 설정했습니다.
+    @Async
     @Scheduled(cron = "0 0 0-5,7-23 * * *", zone = "${github.sync.timezone:Asia/Seoul}")
     public void runHourly30DaysSyncExceptMorningSix() {
         log.info("GitHub 30일 동기화 스케줄러 시작.");
-        syncAndGrant(syncService::syncRecent30Days);
+        try {
+            syncAndGrant(syncService::syncRecent30Days);
+        } catch (Exception e) {
+            log.error("GitHub 30일 동기화 스케줄러 실패.", e);
+        }
     }
 
     // 365일 동기화는 매일 오전 6시에만 작동. (이 시각에는 30일 동기화가 중복되기에 작동하지 않음)
+    @Async
     @Scheduled(cron = "0 0 6 * * *", zone = "${github.sync.timezone:Asia/Seoul}")
     public void runDaily365DaysSyncAtMorningSix() {
         log.info("GitHub 365일 동기화 스케줄러 시작.");
-        syncAndGrant(syncService::syncRecent365Days);
+        try {
+            syncAndGrant(syncService::syncRecent365Days);
+        } catch (Exception e) {
+            log.error("GitHub 365일 동기화 스케줄러 실패.", e);
+        }
         try {
             zeroRankingDataInitService.initZeroExpForToday();
         } catch (Exception e) {


### PR DESCRIPTION
## 변경사항
  - `GithubStatsSyncScheduler`의 `@Scheduled` 메서드에 `@Async` 추가하여 별도 스레드에서 실행되도록 위임                                                                           
  - 기존에 누락되어 있던 `syncAndGrant()` 호출부 예외 처리 추가 

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #590 

## 추가 컨텍스트
  Spring `@Scheduled`은 기본적으로 단일 스레드(`scheduling-1`)를 사용하기 때문에, 실행 시간이 긴 `GithubStatsSyncScheduler`가 해당 스레드를 점유하면 나머지
  스케줄러(`BattleFinishScheduler`, `RankingTierScheduler` 등)의 실행이 지연되는 문제가 있었습니다.

  `@Async`를 추가하면 스케줄러 스레드는 메서드 호출 즉시 반환되고, 실제 동기화 작업은 Spring의 async 스레드풀로 위임됩니다. `@EnableAsync`는 `ClashApplication`에 이미 선언되어
  있어 별도 설정 변경은 없습니다.