### PR TITLE
fix: battle early finish/#641

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
@@ -174,7 +174,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
         JOIN battles b ON b.id IN (:battleIds)
             AND ueh.fk_user_id = :userId
             AND ueh.date >= (b.started_at AT TIME ZONE 'Asia/Seoul')::date
-            AND ueh.date <= (b.end_at AT TIME ZONE 'Asia/Seoul')::date
+            AND ueh.date < (b.end_at AT TIME ZONE 'Asia/Seoul')::date
         GROUP BY b.id
     """, nativeQuery = true)
     List<Object[]> findAverageExpForBattles(

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -28,6 +29,7 @@ public class AcceptBattleService implements AcceptBattleUseCase {
     private final RivalRepositoryPort rivalRepositoryPort;
     private final UserNoticeRepositoryPort userNoticeRepositoryPort;
     private final CompeteRefetchNotifier competeRefetchNotifier;
+    private final ZoneId battleZoneId;
 
     @Override
     public void execute(ModifyBattleData.Command command) {
@@ -37,8 +39,8 @@ public class AcceptBattleService implements AcceptBattleUseCase {
         Battle battle = battleRepositoryPort.findById(command.id())
                 .orElseThrow(BattleNotFoundException::new);
 
-        // 승인 시각을 배틀 시작 시각으로 사용
-        Battle updatedBattle = battle.accept(Instant.now());
+        // 승인 시각을 배틀 시작 시각으로 사용, 종료 시각은 수락일(KST) + duration일의 자정 KST
+        Battle updatedBattle = battle.accept(Instant.now(), battleZoneId);
 
         battleRepositoryPort.save(updatedBattle);
 

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
@@ -172,7 +172,7 @@ public class FindAllBattleInfoService implements FindAllBattleInfoUseCase {
         );
 
         LocalDate expireDate = battle.endAt() != null
-                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                ? battle.endAt().atZone(battleZoneId).toLocalDate().minusDays(1)
                 : null;
 
         return BattleInfo.of(

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindDetailedBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindDetailedBattleInfoService.java
@@ -39,14 +39,14 @@ public class FindDetailedBattleInfoService implements FindDetailedBattleInfoUseC
                 ? battle.startedAt().atZone(battleZoneId).toLocalDate()
                 : LocalDate.now(battleZoneId);
 
-        // exp 계산 기간 종료일: DONE이면 실제 종료일, 진행 중이면 오늘까지
+        // exp 계산 기간 종료일: DONE이면 마지막 활동일(endAt 자정의 전날), 진행 중이면 오늘까지
         LocalDate endDate = battle.battleStatus().equals(BattleStatus.DONE) && battle.endAt() != null
-                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                ? battle.endAt().atZone(battleZoneId).toLocalDate().minusDays(1)
                 : LocalDate.now(battleZoneId);
 
-        // 클라이언트 표시용 종료 예정일: 상태에 무관하게 항상 실제 endAt 기준
+        // 클라이언트 표시용 종료 예정일: endAt 자정의 전날 = 마지막 활동일
         LocalDate expireDate = battle.endAt() != null
-                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                ? battle.endAt().atZone(battleZoneId).toLocalDate().minusDays(1)
                 : null;
 
         // 상대방이 탈퇴해 라이벌이 삭제된 경우 상대 정보 없이 반환

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindDetailedBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindDetailedBattleInfoService.java
@@ -39,16 +39,22 @@ public class FindDetailedBattleInfoService implements FindDetailedBattleInfoUseC
                 ? battle.startedAt().atZone(battleZoneId).toLocalDate()
                 : LocalDate.now(battleZoneId);
 
+        // exp 계산 기간 종료일: DONE이면 실제 종료일, 진행 중이면 오늘까지
         LocalDate endDate = battle.battleStatus().equals(BattleStatus.DONE) && battle.endAt() != null
                 ? battle.endAt().atZone(battleZoneId).toLocalDate()
                 : LocalDate.now(battleZoneId);
+
+        // 클라이언트 표시용 종료 예정일: 상태에 무관하게 항상 실제 endAt 기준
+        LocalDate expireDate = battle.endAt() != null
+                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                : null;
 
         // 상대방이 탈퇴해 라이벌이 삭제된 경우 상대 정보 없이 반환
         if (battle.rivalId() == null) {
             double myAverageExp = userExpHistoryRepositoryPort
                     .findAverageExpByUserIdAndPeriod(command.actor().id(), startDate, endDate);
             double myOverallPercentage = myAverageExp == 0 ? 0 : 100.0;
-            return FindDetailedBattleInfoData.Result.of(battle, null, endDate, myOverallPercentage, null);
+            return FindDetailedBattleInfoData.Result.of(battle, null, expireDate, myOverallPercentage, null);
         }
 
         Rival rival = rivalRepositoryPort.findById(battle.rivalId())
@@ -77,6 +83,6 @@ public class FindDetailedBattleInfoService implements FindDetailedBattleInfoUseC
             enemyOverallPercentage = (enemyAverageExp / totalAverageExp) * 100;
         }
 
-        return FindDetailedBattleInfoData.Result.of(battle, user, endDate, myOverallPercentage, enemyOverallPercentage);
+        return FindDetailedBattleInfoData.Result.of(battle, user, expireDate, myOverallPercentage, enemyOverallPercentage);
     }
 }

--- a/src/main/java/com/process/clash/domain/rival/battle/entity/Battle.java
+++ b/src/main/java/com/process/clash/domain/rival/battle/entity/Battle.java
@@ -3,7 +3,8 @@ package com.process.clash.domain.rival.battle.entity;
 import com.process.clash.domain.rival.battle.enums.BattleStatus;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.time.LocalDate;
+import java.time.ZoneId;
 
 public record Battle(
         Long id,
@@ -34,14 +35,16 @@ public record Battle(
         );
     }
 
-    public Battle accept(Instant now) {
+    public Battle accept(Instant now, ZoneId zoneId) {
+        LocalDate acceptanceDateKST = now.atZone(zoneId).toLocalDate();
+        Instant endAt = acceptanceDateKST.plusDays(this.duration).atStartOfDay(zoneId).toInstant();
 
         return new Battle(
                 this.id,
                 this.createdAt,
                 this.updatedAt,
                 now,
-                now.plus(this.duration, ChronoUnit.DAYS),
+                endAt,
                 this.duration,
                 BattleStatus.IN_PROGRESS,
                 this.winnerId,

--- a/src/test/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -46,6 +47,8 @@ class AcceptBattleServiceTest {
 
     private AcceptBattleService acceptBattleService;
 
+    private static final ZoneId BATTLE_ZONE_ID = ZoneId.of("Asia/Seoul");
+
     @BeforeEach
     void setUp() {
         acceptBattleService = new AcceptBattleService(
@@ -53,7 +56,8 @@ class AcceptBattleServiceTest {
             modifyBattlePolicy,
             rivalRepositoryPort,
             userNoticeRepositoryPort,
-            competeRefetchNotifier
+            competeRefetchNotifier,
+            BATTLE_ZONE_ID
         );
     }
 
@@ -67,7 +71,7 @@ class AcceptBattleServiceTest {
         Battle battle = pendingBattle(battleId, rivalId, opponentId);
 
         when(battleRepositoryPort.findById(battleId)).thenReturn(Optional.of(battle));
-        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now()));
+        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now(), BATTLE_ZONE_ID));
         when(rivalRepositoryPort.findOpponentIdByIdAndUserId(rivalId, actor.id())).thenReturn(opponentId);
         when(userNoticeRepositoryPort.save(any(UserNotice.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -92,7 +96,7 @@ class AcceptBattleServiceTest {
         Battle battle = pendingBattle(battleId, rivalId, opponentId);
 
         when(battleRepositoryPort.findById(battleId)).thenReturn(Optional.of(battle));
-        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now()));
+        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now(), BATTLE_ZONE_ID));
         when(rivalRepositoryPort.findOpponentIdByIdAndUserId(rivalId, actor.id())).thenReturn(opponentId);
         when(userNoticeRepositoryPort.save(any(UserNotice.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -111,7 +115,7 @@ class AcceptBattleServiceTest {
         Battle battle = pendingBattle(battleId, rivalId, opponentId);
 
         when(battleRepositoryPort.findById(battleId)).thenReturn(Optional.of(battle));
-        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now()));
+        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now(), BATTLE_ZONE_ID));
         when(rivalRepositoryPort.findOpponentIdByIdAndUserId(rivalId, actor.id())).thenReturn(opponentId);
         when(userNoticeRepositoryPort.save(any(UserNotice.class))).thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/com/process/clash/domain/rival/battle/entity/BattleTest.java
+++ b/src/test/java/com/process/clash/domain/rival/battle/entity/BattleTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,16 +14,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BattleTest {
 
     @Test
-    @DisplayName("승인 즉시 startedAt이 설정되고 IN_PROGRESS 상태가 된다")
+    @DisplayName("승인 즉시 startedAt이 설정되고, endAt은 수락일(KST) + duration일의 자정 KST로 설정된다")
     void accept_setsStartedAtAndReturnsInProgress() {
         Battle battle = pendingBattle(7);
         Instant now = Instant.now();
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
 
-        Battle result = battle.accept(now);
+        Battle result = battle.accept(now, zoneId);
+
+        LocalDate acceptanceDateKST = now.atZone(zoneId).toLocalDate();
+        Instant expectedEndAt = acceptanceDateKST.plusDays(7).atStartOfDay(zoneId).toInstant();
 
         assertThat(result.battleStatus()).isEqualTo(BattleStatus.IN_PROGRESS);
         assertThat(result.startedAt()).isEqualTo(now);
-        assertThat(result.endAt()).isEqualTo(now.plus(7, ChronoUnit.DAYS));
+        assertThat(result.endAt()).isEqualTo(expectedEndAt);
     }
 
     @Test


### PR DESCRIPTION
## 변경사항   
  - `Battle.accept()`의 `endAt` 계산 방식을 수락 시각 + duration × 24h에서 **수락일(KST) + duration일의 자정 KST**로 변경                                                          
    - 기존: 수락 시각이 오후 2시면 duration일 후 오후 2시에 종료 → 조회 시 lazy finish가 예상보다 일찍 트리거됨
    - 변경: 수락 시각과 무관하게 항상 KST 자정에 종료되도록 통일                                                                                                                   
  - `FindDetailedBattleInfoService`에서 exp 계산용 `endDate`와 클라이언트 표시용 `expireDate`를 분리                                                                               
    - 기존: IN_PROGRESS 배틀의 `expireDate`가 오늘 날짜(KST)로 반환됨
    - 변경: 배틀 상태와 무관하게 항상 실제 `endAt` KST 날짜 반환

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #641 

## 추가 컨텍스트
  스케줄러와 조회 시 lazy finish 모두 `endAt.isBefore(Instant.now())` Instant 비교를 사용하므로 KST 변환 로직 자체에는 문제가 없었음. 근본 원인은 `endAt` 값 자체가 KST 날짜
  경계(자정)가 아닌 수락 시각 기준이었던 것. V28 마이그레이션에서 기존 데이터를 `end_date || 'T00:00:00+09:00'` 로 변환한 방식과 일관성을 맞춰 수정함.