### PR TITLE
fix: battle finish/#645

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
@@ -174,7 +174,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
         JOIN battles b ON b.id IN (:battleIds)
             AND ueh.fk_user_id = :userId
             AND ueh.date >= (b.started_at AT TIME ZONE 'Asia/Seoul')::date
-            AND ueh.date <= (b.end_at AT TIME ZONE 'Asia/Seoul')::date
+            AND ueh.date <= ((b.end_at - interval '1 microsecond') AT TIME ZONE 'Asia/Seoul')::date
         GROUP BY b.id
     """, nativeQuery = true)
     List<Object[]> findAverageExpForBattles(

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -29,7 +28,6 @@ public class AcceptBattleService implements AcceptBattleUseCase {
     private final RivalRepositoryPort rivalRepositoryPort;
     private final UserNoticeRepositoryPort userNoticeRepositoryPort;
     private final CompeteRefetchNotifier competeRefetchNotifier;
-    private final ZoneId battleZoneId;
 
     @Override
     public void execute(ModifyBattleData.Command command) {
@@ -39,8 +37,7 @@ public class AcceptBattleService implements AcceptBattleUseCase {
         Battle battle = battleRepositoryPort.findById(command.id())
                 .orElseThrow(BattleNotFoundException::new);
 
-        // 승인 시각을 배틀 시작 시각으로 사용, 종료 시각은 수락일(KST) + duration일의 자정 KST
-        Battle updatedBattle = battle.accept(Instant.now(), battleZoneId);
+        Battle updatedBattle = battle.accept(Instant.now());
 
         battleRepositoryPort.save(updatedBattle);
 

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
@@ -172,7 +172,7 @@ public class FindAllBattleInfoService implements FindAllBattleInfoUseCase {
         );
 
         LocalDate expireDate = battle.endAt() != null
-                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                ? battle.endAt().minusNanos(1).atZone(battleZoneId).toLocalDate()
                 : null;
 
         return BattleInfo.of(

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindDetailedBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindDetailedBattleInfoService.java
@@ -41,12 +41,12 @@ public class FindDetailedBattleInfoService implements FindDetailedBattleInfoUseC
 
         // exp 계산 기간 종료일: DONE이면 endAt 기준 날짜, 진행 중이면 오늘까지
         LocalDate endDate = battle.battleStatus().equals(BattleStatus.DONE) && battle.endAt() != null
-                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                ? battle.endAt().minusNanos(1).atZone(battleZoneId).toLocalDate()
                 : LocalDate.now(battleZoneId);
 
         // 클라이언트 표시용 종료 예정일: endAt 기준 날짜 (마지막 활동일)
         LocalDate expireDate = battle.endAt() != null
-                ? battle.endAt().atZone(battleZoneId).toLocalDate()
+                ? battle.endAt().minusNanos(1).atZone(battleZoneId).toLocalDate()
                 : null;
 
         // 상대방이 탈퇴해 라이벌이 삭제된 경우 상대 정보 없이 반환

--- a/src/main/java/com/process/clash/domain/rival/battle/entity/Battle.java
+++ b/src/main/java/com/process/clash/domain/rival/battle/entity/Battle.java
@@ -3,7 +3,6 @@ package com.process.clash.domain.rival.battle.entity;
 import com.process.clash.domain.rival.battle.enums.BattleStatus;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 public record Battle(
@@ -35,7 +34,7 @@ public record Battle(
         );
     }
 
-    public Battle accept(Instant now, ZoneId zoneId) {
+    public Battle accept(Instant now) {
         Instant endAt = now.plus(this.duration, ChronoUnit.DAYS);
 
         return new Battle(

--- a/src/test/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/battle/service/AcceptBattleServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -47,8 +46,6 @@ class AcceptBattleServiceTest {
 
     private AcceptBattleService acceptBattleService;
 
-    private static final ZoneId BATTLE_ZONE_ID = ZoneId.of("Asia/Seoul");
-
     @BeforeEach
     void setUp() {
         acceptBattleService = new AcceptBattleService(
@@ -56,8 +53,7 @@ class AcceptBattleServiceTest {
             modifyBattlePolicy,
             rivalRepositoryPort,
             userNoticeRepositoryPort,
-            competeRefetchNotifier,
-            BATTLE_ZONE_ID
+            competeRefetchNotifier
         );
     }
 
@@ -71,7 +67,7 @@ class AcceptBattleServiceTest {
         Battle battle = pendingBattle(battleId, rivalId, opponentId);
 
         when(battleRepositoryPort.findById(battleId)).thenReturn(Optional.of(battle));
-        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now(), BATTLE_ZONE_ID));
+        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now()));
         when(rivalRepositoryPort.findOpponentIdByIdAndUserId(rivalId, actor.id())).thenReturn(opponentId);
         when(userNoticeRepositoryPort.save(any(UserNotice.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -96,7 +92,7 @@ class AcceptBattleServiceTest {
         Battle battle = pendingBattle(battleId, rivalId, opponentId);
 
         when(battleRepositoryPort.findById(battleId)).thenReturn(Optional.of(battle));
-        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now(), BATTLE_ZONE_ID));
+        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now()));
         when(rivalRepositoryPort.findOpponentIdByIdAndUserId(rivalId, actor.id())).thenReturn(opponentId);
         when(userNoticeRepositoryPort.save(any(UserNotice.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -115,7 +111,7 @@ class AcceptBattleServiceTest {
         Battle battle = pendingBattle(battleId, rivalId, opponentId);
 
         when(battleRepositoryPort.findById(battleId)).thenReturn(Optional.of(battle));
-        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now(), BATTLE_ZONE_ID));
+        when(battleRepositoryPort.save(any(Battle.class))).thenReturn(battle.accept(Instant.now()));
         when(rivalRepositoryPort.findOpponentIdByIdAndUserId(rivalId, actor.id())).thenReturn(opponentId);
         when(userNoticeRepositoryPort.save(any(UserNotice.class))).thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoServiceTest.java
@@ -205,7 +205,7 @@ class FindAllBattleInfoServiceTest {
 
         FindAllBattleInfoData.Result result = findAllBattleInfoService.execute(command());
 
-        LocalDate expectedDate = endAt.atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
+        LocalDate expectedDate = endAt.minusNanos(1).atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
         assertThat(result.battles().get(0).expireDate()).isEqualTo(expectedDate);
     }
 

--- a/src/test/java/com/process/clash/domain/rival/battle/entity/BattleTest.java
+++ b/src/test/java/com/process/clash/domain/rival/battle/entity/BattleTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,9 +16,8 @@ class BattleTest {
     void accept_setsStartedAtAndReturnsInProgress() {
         Battle battle = pendingBattle(7);
         Instant now = Instant.now();
-        ZoneId zoneId = ZoneId.of("Asia/Seoul");
 
-        Battle result = battle.accept(now, zoneId);
+        Battle result = battle.accept(now);
 
         Instant expectedEndAt = now.plus(7, ChronoUnit.DAYS);
 


### PR DESCRIPTION
## 변경사항
  - `Battle.accept()`: 배틀 종료 시각을 수락일 자정 기준에서 수락 시각 + N일(72시간 단위)로 변경                                                                                   
    - 4/6 22:00 수락 + 3일 → 기존 4/9 00:00 → **4/9 22:00**으로 수정
  - `FindDetailedBattleInfoService`, `FindAllBattleInfoService`: `expireDate`에서 `.minusDays(1)` 제거                                                                             
    - `endAt`이 더 이상 자정이 아니므로 `endAt`의 KST 날짜가 곧 마지막 활동일
  - `UserExpHistoryJpaRepository.findAverageExpForBattles` 쿼리: `< end_at::date` → `<= end_at::date`
    - 종료 당일 exp 집계가 누락되던 문제 수정
  - 위 변경에 맞게 `BattleTest`, `FindAllBattleInfoServiceTest` 수정

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #645 

## 추가 컨텍스트
  - 스케줄러 및 조회 시 lazy finish(`isExpiredInProgress`) 흐름은 변경 없음
    — `endAt.isBefore(now)` 판단 기준이 동일하게 유지되므로 자연스럽게 적용됨
  - 이전 커밋(#641)에서 `expireDate`가 오늘 날짜로 고정되는 버그를 수정했으나,
    종료 시각 계산 자체의 의도가 잘못되어 있어 근본 원인을 이번에 수정