### PR TITLE
fix: able rival list/#624

### DIFF
--- a/src/main/java/com/process/clash/application/compete/rival/rival/service/GetAllAbleRivalsService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/rival/service/GetAllAbleRivalsService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -19,15 +21,21 @@ import java.util.stream.Stream;
 @Transactional(readOnly = true)
 public class GetAllAbleRivalsService implements GetAllAbleRivalsUseCase {
 
+    private static final int MAX_RIVAL_COUNT = 4;
+
     private final RivalRepositoryPort rivalRepositoryPort;
     private final UserRepositoryPort userRepositoryPort;
 
     @Override
     public GetAllAbleRivalsData.Result execute(GetAllAbleRivalsData.Command command) {
 
-        List<Rival> rivals = rivalRepositoryPort.findAllRivalsByUserId(command.actor().id());
-
         Long myId = command.actor().id();
+
+        if (rivalRepositoryPort.countAcceptedByUserId(myId) >= MAX_RIVAL_COUNT) {
+            return GetAllAbleRivalsData.Result.from(List.of());
+        }
+
+        List<Rival> rivals = rivalRepositoryPort.findAllRivalsByUserId(myId);
 
         List<Long> excludedUserIds = Stream.concat(
                 rivals.stream()
@@ -42,8 +50,23 @@ public class GetAllAbleRivalsService implements GetAllAbleRivalsUseCase {
                 Stream.of(myId)
         ).distinct().toList();
 
+        List<AbleRivalInfoForRival> candidates = userRepositoryPort.findAbleRivalsWithUserInfo(excludedUserIds);
 
-        List<AbleRivalInfoForRival> ableRivalInfoForRivals = userRepositoryPort.findAbleRivalsWithUserInfo(excludedUserIds);
+        if (candidates.isEmpty()) {
+            return GetAllAbleRivalsData.Result.from(List.of());
+        }
+
+        List<Long> candidateIds = candidates.stream().map(AbleRivalInfoForRival::id).toList();
+        Map<Long, Integer> acceptedCounts = rivalRepositoryPort.countAcceptedByUserIdsGrouped(candidateIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        map -> ((Number) map.get("user_id")).longValue(),
+                        map -> ((Number) map.get("count")).intValue()
+                ));
+
+        List<AbleRivalInfoForRival> ableRivalInfoForRivals = candidates.stream()
+                .filter(user -> acceptedCounts.getOrDefault(user.id(), 0) < MAX_RIVAL_COUNT)
+                .toList();
 
         return GetAllAbleRivalsData.Result.from(ableRivalInfoForRivals);
     }

--- a/src/main/java/com/process/clash/application/compete/rival/rival/service/SearchRivalByKeywordService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/rival/service/SearchRivalByKeywordService.java
@@ -6,17 +6,22 @@ import com.process.clash.application.compete.rival.rival.port.in.SearchRivalByKe
 import com.process.clash.application.compete.rival.rival.port.out.RivalRepositoryPort;
 import com.process.clash.application.user.usergithub.port.out.UserGitHubRepositoryPort;
 import com.process.clash.domain.rival.rival.entity.Rival;
+import com.process.clash.domain.rival.rival.enums.RivalLinkingStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SearchRivalByKeywordService implements SearchRivalByKeywordUseCase {
+
+    private static final int MAX_RIVAL_COUNT = 4;
 
     private final RivalRepositoryPort rivalRepositoryPort;
     private final UserGitHubRepositoryPort userGitHubRepositoryPort;
@@ -26,10 +31,16 @@ public class SearchRivalByKeywordService implements SearchRivalByKeywordUseCase 
 
         Long myId = command.actor().id();
 
-        List<Rival> rivals = rivalRepositoryPort.findAllByUserId(myId);
+        if (rivalRepositoryPort.countAcceptedByUserId(myId) >= MAX_RIVAL_COUNT) {
+            return SearchRivalByKeywordData.Result.from(List.of());
+        }
+
+        List<Rival> rivals = rivalRepositoryPort.findAllRivalsByUserId(myId);
 
         List<Long> excludedUserIds = Stream.concat(
                 rivals.stream()
+                        .filter(rival -> rival.rivalLinkingStatus() == RivalLinkingStatus.PENDING
+                                || rival.rivalLinkingStatus() == RivalLinkingStatus.ACCEPTED)
                         .map(rival -> {
                             if (rival.firstUserId().equals(myId)) {
                                 return rival.secondUserId();
@@ -38,13 +49,29 @@ public class SearchRivalByKeywordService implements SearchRivalByKeywordUseCase 
                             }
                         }),
                 Stream.of(myId)
-        ).toList();
+        ).distinct().toList();
 
-        List<AbleRivalInfoForRival> ableRivalInfoForRivals =
+        List<AbleRivalInfoForRival> candidates =
                 userGitHubRepositoryPort.findAbleRivalsWithUserInfoByKeyword(
                         excludedUserIds,
                         command.keyword()
                 );
+
+        if (candidates.isEmpty()) {
+            return SearchRivalByKeywordData.Result.from(List.of());
+        }
+
+        List<Long> candidateIds = candidates.stream().map(AbleRivalInfoForRival::id).toList();
+        Map<Long, Integer> acceptedCounts = rivalRepositoryPort.countAcceptedByUserIdsGrouped(candidateIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        map -> ((Number) map.get("user_id")).longValue(),
+                        map -> ((Number) map.get("count")).intValue()
+                ));
+
+        List<AbleRivalInfoForRival> ableRivalInfoForRivals = candidates.stream()
+                .filter(user -> acceptedCounts.getOrDefault(user.id(), 0) < MAX_RIVAL_COUNT)
+                .toList();
 
         return SearchRivalByKeywordData.Result.from(ableRivalInfoForRivals);
     }


### PR DESCRIPTION
## 변경사항
  - 라이벌 신청 가능 목록 조회 시 신청 불가 대상 제외 조건 추가                                                                                                                    
    - 내가 ACCEPTED 라이벌이 4명 이상인 경우 빈 목록 반환
    - 상대방이 ACCEPTED 라이벌이 4명 이상인 경우 목록에서 제외                                                                                                                     
  - 키워드 검색(`SearchRivalByKeywordService`)에서 PENDING 상태 라이벌을 제외하지 않던 버그 수정  

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #624 

## 추가 컨텍스트
  신청 가능 목록이지만 실제로 신청 시 `ApplyRivalPolicy`에서 거부되는 유저(라이벌 4명 초과, PENDING 중복)가 노출되는 문제를 사전에 필터링합니다.
  상대방의 ACCEPTED 카운트는 후보 유저 목록을 먼저 조회한 뒤 `countAcceptedByUserIdsGrouped`로 배치 조회하여 N+1 없이 처리합니다.