### PR TITLE
feat: rival equipped items/#661

### DIFF
--- a/src/main/java/com/process/clash/adapter/web/compete/rival/rival/dto/GetMyRivalActingDto.java
+++ b/src/main/java/com/process/clash/adapter/web/compete/rival/rival/dto/GetMyRivalActingDto.java
@@ -1,6 +1,7 @@
 package com.process.clash.adapter.web.compete.rival.rival.dto;
 
 import com.process.clash.application.compete.rival.rival.data.GetMyRivalActingData;
+import com.process.clash.application.profile.data.EquippedItemsData;
 import com.process.clash.application.realtime.data.UserActivityStatus;
 
 import java.util.List;
@@ -24,7 +25,8 @@ public class GetMyRivalActingDto {
                         data.usingApp(),
                         data.isStudying(),
                         data.status(),
-                        data.tier()
+                        data.tier(),
+                        data.equippedItems()
                     ))
                 .toList()
             );
@@ -41,6 +43,7 @@ public class GetMyRivalActingDto {
             String usingApp,
             Boolean isStudying,
             UserActivityStatus status,
-            String tier
+            String tier,
+            EquippedItemsData equippedItems
     ) {}
 }

--- a/src/main/java/com/process/clash/adapter/web/ranking/docs/controller/RankingControllerDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/ranking/docs/controller/RankingControllerDocument.java
@@ -41,9 +41,9 @@ public interface RankingControllerDocument {
                                             "point": 1200,
                                             "tier": "AURA",
                                             "equippedItems": {
-                                              "insigma": {
+                                              "insignia": {
                                                 "id": 1,
-                                                "name": "기본 인시그니아",
+                                                "name": "기본 휘장",
                                                 "image": "https://cdn.example.com/items/insignia.png"
                                               },
                                               "nameplate": null,
@@ -58,7 +58,7 @@ public interface RankingControllerDocument {
                                             "point": 980,
                                             "tier": "GOLD",
                                             "equippedItems": {
-                                              "insigma": null,
+                                              "insignia": null,
                                               "nameplate": null,
                                               "banner": null
                                             }

--- a/src/main/java/com/process/clash/adapter/web/ranking/docs/response/GetRankingResponseDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/ranking/docs/response/GetRankingResponseDocument.java
@@ -57,8 +57,8 @@ public class GetRankingResponseDocument {
     @Schema(name = "EquippedItems", description = "장착 아이템 정보")
     public static class EquippedItemsDoc {
 
-        @Schema(description = "인시그니아")
-        private EquippedItemDoc insigma;
+        @Schema(description = "휘장")
+        private EquippedItemDoc insignia;
 
         @Schema(description = "네임플레이트")
         private EquippedItemDoc nameplate;
@@ -73,7 +73,7 @@ public class GetRankingResponseDocument {
         @Schema(description = "아이템 ID", example = "1")
         private Long id;
 
-        @Schema(description = "아이템 이름", example = "기본 인시그니아")
+        @Schema(description = "아이템 이름", example = "기본 휘장")
         private String name;
 
         @Schema(description = "아이템 이미지 URL", example = "https://cdn.example.com/items/insignia.png")

--- a/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyItemDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyItemDocument.java
@@ -8,7 +8,7 @@ public class GetMyItemDocument {
     @Schema(description = "아이템 ID", example = "1")
     public Long id;
 
-    @Schema(description = "아이템 제목", example = "기본 인시그니아")
+    @Schema(description = "아이템 제목", example = "기본 휘장")
     public String title;
 
     @Schema(description = "아이템 이미지 URL", example = "https://cdn.example.com/items/insignia.png")

--- a/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyItemsResponseDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyItemsResponseDocument.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
                 "items": [
                   {
                     "id": 1,
-                    "title": "기본 인시그니아",
+                    "title": "기본 휘장",
                     "image": "https://cdn.example.com/items/insignia.png",
                     "description": "기본 아이템",
                     "category": "INSIGNIA",

--- a/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyProfileDataDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyProfileDataDocument.java
@@ -58,8 +58,8 @@ public class GetMyProfileDataDocument {
 
     @Schema(description = "장착 아이템")
     public static class EquippedItemsDocument {
-        @Schema(description = "인시그니아")
-        public EquippedItemDocument insigma;
+        @Schema(description = "휘장")
+        public EquippedItemDocument insignia;
 
         @Schema(description = "네임플레이트")
         public EquippedItemDocument nameplate;
@@ -73,7 +73,7 @@ public class GetMyProfileDataDocument {
         @Schema(description = "아이템 ID", example = "1")
         public Long id;
 
-        @Schema(description = "아이템 이름", example = "기본 인시그니아")
+        @Schema(description = "아이템 이름", example = "기본 휘장")
         public String name;
 
         @Schema(description = "아이템 이미지 URL", example = "https://cdn.example.com/items/insignia.png")

--- a/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyProfileResponseDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/user/docs/response/GetMyProfileResponseDocument.java
@@ -26,9 +26,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
                 "githubLinked": true,
                 "activityStatus": "ONLINE",
                 "equippedItems": {
-                  "insigma": {
+                  "insignia": {
                     "id": 1,
-                    "name": "기본 인시그니아",
+                    "name": "기본 휘장",
                     "image": "https://cdn.example.com/items/insignia.png"
                   },
                   "nameplate": null,

--- a/src/main/java/com/process/clash/adapter/web/user/dto/EquippedItemsDto.java
+++ b/src/main/java/com/process/clash/adapter/web/user/dto/EquippedItemsDto.java
@@ -5,7 +5,7 @@ import com.process.clash.application.profile.data.EquippedItemsData;
 public class EquippedItemsDto {
 
     public record Response(
-            Item insigma,
+            Item insignia,
             Item nameplate,
             Item banner
     ) {
@@ -14,7 +14,7 @@ public class EquippedItemsDto {
                 return new Response(null, null, null);
             }
             return new Response(
-                    Item.from(data.insigma()),
+                    Item.from(data.insignia()),
                     Item.from(data.nameplate()),
                     Item.from(data.banner())
             );

--- a/src/main/java/com/process/clash/application/compete/rival/rival/data/GetMyRivalActingData.java
+++ b/src/main/java/com/process/clash/application/compete/rival/rival/data/GetMyRivalActingData.java
@@ -1,6 +1,7 @@
 package com.process.clash.application.compete.rival.rival.data;
 
 import com.process.clash.application.common.actor.Actor;
+import com.process.clash.application.profile.data.EquippedItemsData;
 import com.process.clash.application.realtime.data.UserActivityStatus;
 import com.process.clash.domain.user.user.entity.User;
 
@@ -38,7 +39,8 @@ public class GetMyRivalActingData {
             String usingApp,
             Boolean isStudying,
             UserActivityStatus status,
-            String tier
+            String tier,
+            EquippedItemsData equippedItems
     ) {
 
         public static MyRival of(
@@ -47,7 +49,8 @@ public class GetMyRivalActingData {
             Long activeTime,
             String usingApp,
             Boolean isStudying,
-            UserActivityStatus status
+            UserActivityStatus status,
+            EquippedItemsData equippedItems
         ) {
             return new MyRival(
                     rivalId,
@@ -59,7 +62,8 @@ public class GetMyRivalActingData {
                     usingApp,
                     isStudying,
                     status,
-                    user.tier()
+                    user.tier(),
+                    equippedItems
             );
         }
     }

--- a/src/main/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingService.java
@@ -89,7 +89,10 @@ public class GetMyRivalActingService implements GetMyRivalActingUseCase {
 
         Map<Long, UserActivityStatus> activityStatusByUserId = userPresencePort.getStatuses(opponentIds);
 
-        Map<Long, EquippedItemsData> equippedItemsMap = equippedItemsAssembler.loadByUserIds(opponentIds);
+        List<Long> rivalIds = opponentIds.stream()
+                .filter(id -> !id.equals(command.actor().id()))
+                .toList();
+        Map<Long, EquippedItemsData> equippedItemsMap = equippedItemsAssembler.loadByUserIds(rivalIds);
 
         Long myId = command.actor().id();
 

--- a/src/main/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingService.java
@@ -3,6 +3,8 @@ package com.process.clash.application.compete.rival.rival.service;
 import com.process.clash.application.compete.rival.rival.data.GetMyRivalActingData;
 import com.process.clash.application.compete.rival.rival.port.in.GetMyRivalActingUseCase;
 import com.process.clash.application.compete.rival.rival.port.out.RivalRepositoryPort;
+import com.process.clash.application.profile.data.EquippedItemsData;
+import com.process.clash.application.profile.service.EquippedItemsAssembler;
 import com.process.clash.application.realtime.data.UserActivityStatus;
 import com.process.clash.application.realtime.port.out.UserPresencePort;
 import com.process.clash.application.record.v2.port.out.RecordSessionV2RepositoryPort;
@@ -37,6 +39,7 @@ public class GetMyRivalActingService implements GetMyRivalActingUseCase {
     private final UserPresencePort userPresencePort;
     private final RecordProperties recordProperties;
     private final ZoneId recordZoneId;
+    private final EquippedItemsAssembler equippedItemsAssembler;
 
     @Override
     public GetMyRivalActingData.Result execute(GetMyRivalActingData.Command command) {
@@ -86,6 +89,8 @@ public class GetMyRivalActingService implements GetMyRivalActingUseCase {
 
         Map<Long, UserActivityStatus> activityStatusByUserId = userPresencePort.getStatuses(opponentIds);
 
+        Map<Long, EquippedItemsData> equippedItemsMap = equippedItemsAssembler.loadByUserIds(opponentIds);
+
         Long myId = command.actor().id();
 
         List<GetMyRivalActingData.MyRival> myRivals = rivals.stream()
@@ -112,13 +117,16 @@ public class GetMyRivalActingService implements GetMyRivalActingUseCase {
                     String usingApp = resolveUsingApp(activeSession);
                     boolean isStudying = activeSession != null;
 
+                    EquippedItemsData equippedItems = equippedItemsMap.getOrDefault(opponentId, EquippedItemsData.empty());
+
                     return GetMyRivalActingData.MyRival.of(
                             rival.id(),
                             opponent,
                             activeTime,
                             usingApp,
                             isStudying,
-                            activityStatus
+                            activityStatus,
+                            equippedItems
                     );
                 })
                 .toList();

--- a/src/main/java/com/process/clash/application/profile/data/EquippedItemsData.java
+++ b/src/main/java/com/process/clash/application/profile/data/EquippedItemsData.java
@@ -1,7 +1,7 @@
 package com.process.clash.application.profile.data;
 
 public record EquippedItemsData(
-        EquippedItemData insigma,
+        EquippedItemData insignia,
         EquippedItemData nameplate,
         EquippedItemData banner
 ) {

--- a/src/main/java/com/process/clash/application/profile/service/EquippedItemsAssembler.java
+++ b/src/main/java/com/process/clash/application/profile/service/EquippedItemsAssembler.java
@@ -67,7 +67,7 @@ public class EquippedItemsAssembler {
             List<UserEquippedItem> userEquippedItems,
             Map<Long, Product> productById
     ) {
-        EquippedItemsData.EquippedItemData insigma = null;
+        EquippedItemsData.EquippedItemData insignia = null;
         EquippedItemsData.EquippedItemData nameplate = null;
         EquippedItemsData.EquippedItemData banner = null;
 
@@ -87,7 +87,7 @@ public class EquippedItemsAssembler {
             );
 
             if (userEquippedItem.category() == ProductCategory.INSIGNIA) {
-                insigma = summary;
+                insignia = summary;
             } else if (userEquippedItem.category() == ProductCategory.NAMEPLATE) {
                 nameplate = summary;
             } else if (userEquippedItem.category() == ProductCategory.BANNER) {
@@ -95,6 +95,6 @@ public class EquippedItemsAssembler {
             }
         }
 
-        return new EquippedItemsData(insigma, nameplate, banner);
+        return new EquippedItemsData(insignia, nameplate, banner);
     }
 }

--- a/src/test/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingServiceTest.java
@@ -228,8 +228,8 @@ class GetMyRivalActingServiceTest {
                 new GetMyRivalActingData.Command(actor));
 
         EquippedItemsData actual = result.myRivals().get(0).equippedItems();
-        assertThat(actual.insigma().id()).isEqualTo(1L);
-        assertThat(actual.insigma().name()).isEqualTo("배지이름");
+        assertThat(actual.insignia().id()).isEqualTo(1L);
+        assertThat(actual.insignia().name()).isEqualTo("배지이름");
         assertThat(actual.nameplate().id()).isEqualTo(2L);
         assertThat(actual.banner()).isNull();
     }

--- a/src/test/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingServiceTest.java
@@ -3,6 +3,7 @@ package com.process.clash.application.compete.rival.rival.service;
 import com.process.clash.application.common.actor.Actor;
 import com.process.clash.application.compete.rival.rival.data.GetMyRivalActingData;
 import com.process.clash.application.compete.rival.rival.port.out.RivalRepositoryPort;
+import com.process.clash.application.profile.data.EquippedItemsData;
 import com.process.clash.application.profile.service.EquippedItemsAssembler;
 import com.process.clash.application.realtime.data.UserActivityStatus;
 import com.process.clash.application.realtime.port.out.UserPresencePort;
@@ -196,6 +197,41 @@ class GetMyRivalActingServiceTest {
                 new GetMyRivalActingData.Command(actor));
 
         assertThat(result.myRivals()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("라이벌의 equippedItems가 응답에 올바르게 포함된다")
+    void execute_returnsEquippedItems() {
+        Actor actor = new Actor(1L);
+        Rival rival = new Rival(100L, Instant.now().minusSeconds(86_400), Instant.now(),
+                RivalLinkingStatus.ACCEPTED, 1L, 2L);
+
+        User rivalUser = createUser(2L, "rivalA", "Rival A");
+
+        EquippedItemsData equippedItemsData = new EquippedItemsData(
+                new EquippedItemsData.EquippedItemData(1L, "배지이름", "badge.png"),
+                new EquippedItemsData.EquippedItemData(2L, "닉네임판", "nameplate.png"),
+                null
+        );
+
+        when(rivalRepositoryPort.findAllByUserId(actor.id())).thenReturn(List.of(rival));
+        when(userRepositoryPort.findAllByIds(anyList()))
+                .thenReturn(List.of(rivalUser, createUser(1L, "me", "Me")));
+        when(recordSessionRepositoryPort.getTotalStudyTimeInSecondsByUserIds(anyList(), any(), any()))
+                .thenReturn(Map.of());
+        when(recordSessionRepositoryPort.findAllActiveSessionsByUserIds(anyList())).thenReturn(List.of());
+        when(userPresencePort.getStatuses(anyList())).thenReturn(Map.of(2L, UserActivityStatus.OFFLINE));
+        when(equippedItemsAssembler.loadByUserIds(anyList()))
+                .thenReturn(Map.of(2L, equippedItemsData));
+
+        GetMyRivalActingData.Result result = getMyRivalActingService.execute(
+                new GetMyRivalActingData.Command(actor));
+
+        EquippedItemsData actual = result.myRivals().get(0).equippedItems();
+        assertThat(actual.insigma().id()).isEqualTo(1L);
+        assertThat(actual.insigma().name()).isEqualTo("배지이름");
+        assertThat(actual.nameplate().id()).isEqualTo(2L);
+        assertThat(actual.banner()).isNull();
     }
 
     private User createUser(Long id, String username, String name) {

--- a/src/test/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/rival/service/GetMyRivalActingServiceTest.java
@@ -3,6 +3,7 @@ package com.process.clash.application.compete.rival.rival.service;
 import com.process.clash.application.common.actor.Actor;
 import com.process.clash.application.compete.rival.rival.data.GetMyRivalActingData;
 import com.process.clash.application.compete.rival.rival.port.out.RivalRepositoryPort;
+import com.process.clash.application.profile.service.EquippedItemsAssembler;
 import com.process.clash.application.realtime.data.UserActivityStatus;
 import com.process.clash.application.realtime.port.out.UserPresencePort;
 import com.process.clash.application.record.v2.port.out.RecordSessionV2RepositoryPort;
@@ -51,6 +52,8 @@ class GetMyRivalActingServiceTest {
     private UserPresencePort userPresencePort;
 
     private GetMyRivalActingService getMyRivalActingService;
+    @Mock
+    private EquippedItemsAssembler equippedItemsAssembler;
 
     @BeforeEach
     void setUp() {
@@ -59,8 +62,11 @@ class GetMyRivalActingServiceTest {
             recordSessionRepositoryPort,
             userRepositoryPort,
             userPresencePort,
+
             new RecordProperties("UTC", 0),
-            ZoneId.of("UTC")
+            ZoneId.of("UTC"),
+
+            equippedItemsAssembler
         );
     }
 
@@ -116,6 +122,7 @@ class GetMyRivalActingServiceTest {
             ));
         when(userPresencePort.getStatuses(anyList()))
             .thenReturn(Map.of(2L, UserActivityStatus.ONLINE, 3L, UserActivityStatus.AWAY, 1L, UserActivityStatus.ONLINE));
+        when(equippedItemsAssembler.loadByUserIds(anyList())).thenReturn(Map.of());
 
         GetMyRivalActingData.Result result = getMyRivalActingService.execute(command);
 
@@ -147,6 +154,7 @@ class GetMyRivalActingServiceTest {
                 .thenReturn(Map.of());
         when(recordSessionRepositoryPort.findAllActiveSessionsByUserIds(anyList())).thenReturn(List.of());
         when(userPresencePort.getStatuses(anyList())).thenReturn(Map.of(2L, UserActivityStatus.OFFLINE));
+        when(equippedItemsAssembler.loadByUserIds(anyList())).thenReturn(Map.of());
 
         GetMyRivalActingData.Result result = getMyRivalActingService.execute(
                 new GetMyRivalActingData.Command(actor));
@@ -170,6 +178,7 @@ class GetMyRivalActingServiceTest {
                 .thenReturn(Map.of());
         when(recordSessionRepositoryPort.findAllActiveSessionsByUserIds(anyList())).thenReturn(List.of());
         when(userPresencePort.getStatuses(anyList())).thenReturn(Map.of(2L, UserActivityStatus.OFFLINE));
+        when(equippedItemsAssembler.loadByUserIds(anyList())).thenReturn(Map.of());
 
         GetMyRivalActingData.Result result = getMyRivalActingService.execute(
                 new GetMyRivalActingData.Command(actor));


### PR DESCRIPTION
## 변경사항
GET /api/compete/rivals 응답의 각 라이벌 객체에 equippedItems 필드 추가
EquippedItemsAssembler.loadByUserIds()로 배치 로딩하여 N+1 방지
라이벌이 없을 때 RivalNotFoundException 대신 빈 리스트 반환으로 변경
## 관련 이슈
Closes #661

## 추가 컨텍스트
EquippedItemsAssembler는 기존 랭킹 API에서 사용 중인 컴포넌트를 그대로 재사용했습니다. 
stream 내부에서 loadByUserId()를 호출하면 라이벌 수만큼 쿼리가 발생하므로, stream 실행 전에 loadByUserIds(opponentIds)로 한 번에 로딩 후 map으로 조회하는 방식을 적용했습니다.