### PR TITLE
refactor: ignore canceled battles/#659

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/rival/battle/BattleJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/rival/battle/BattleJpaRepository.java
@@ -116,20 +116,6 @@ public interface BattleJpaRepository extends JpaRepository<BattleJpaEntity, Long
     List<BattleJpaEntity> findExpiredInProgressBattles();
 
     /**
-     * 종료 시각이 지났으나 아직 NOT_STARTED 상태인 배틀 조회 → CANCELED 처리 (스케줄러용)
-     * soft-delete된 라이벌(fk_rival_id IS NULL)은 제외
-     */
-    @Query(value = """
-        SELECT b.*
-        FROM battles b
-        WHERE b.battle_status = 'NOT_STARTED'
-          AND b.fk_rival_id IS NOT NULL
-          AND b.end_at IS NOT NULL
-          AND b.end_at < NOW()
-    """, nativeQuery = true)
-    List<BattleJpaEntity> findExpiredNotStartedBattles();
-
-    /**
      * 유저 관련 PENDING 상태 배틀 신청 목록 조회
      */
     @Query(value = """

--- a/src/main/java/com/process/clash/adapter/persistence/rival/battle/BattleJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/rival/battle/BattleJpaRepository.java
@@ -48,7 +48,7 @@ public interface BattleJpaRepository extends JpaRepository<BattleJpaEntity, Long
         FROM battles b
         LEFT JOIN rivals r ON b.fk_rival_id = r.id
         WHERE (r.fk_first_user_id = :userId OR r.fk_second_user_id = :userId)
-            AND b.battle_status NOT IN ('REJECTED', 'PENDING')
+            AND b.battle_status NOT IN ('REJECTED', 'PENDING', 'CANCELED')
     """, nativeQuery = true)
     List<BattleJpaEntity> findByUserIdWithOutRejected(@Param("userId") Long userId);
 

--- a/src/main/java/com/process/clash/adapter/persistence/rival/battle/BattlePersistenceAdapter.java
+++ b/src/main/java/com/process/clash/adapter/persistence/rival/battle/BattlePersistenceAdapter.java
@@ -108,14 +108,6 @@ public class BattlePersistenceAdapter implements BattleRepositoryPort {
     }
 
     @Override
-    public List<Battle> findExpiredNotStartedBattles() {
-        return battleJpaRepository.findExpiredNotStartedBattles()
-                .stream()
-                .map(battleJpaMapper::toDomain)
-                .toList();
-    }
-
-    @Override
     public List<Battle> findPendingBattlesByUserId(Long userId) {
         return battleJpaRepository.findPendingBattlesByUserId(userId)
                 .stream()

--- a/src/main/java/com/process/clash/adapter/web/compete/rival/battle/docs/controller/BattleControllerDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/compete/rival/battle/docs/controller/BattleControllerDocument.java
@@ -47,7 +47,7 @@ public interface BattleControllerDocument {
             ApplyBattleDto.Request request
     );
 
-    @Operation(summary = "배틀 승인", description = "신청받은 배틀을 승인합니다. 승인 후 배틀은 NOT_STARTED 상태가 되며, 시작일 KST 06시에 자동으로 IN_PROGRESS로 전환됩니다.")
+    @Operation(summary = "배틀 승인", description = "신청받은 배틀을 승인합니다. 승인 즉시 배틀이 IN_PROGRESS 상태로 시작됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "승인 성공",
                     content = @Content(

--- a/src/main/java/com/process/clash/adapter/web/compete/rival/battle/docs/response/FindAllBattleInfoResponseDocument.java
+++ b/src/main/java/com/process/clash/adapter/web/compete/rival/battle/docs/response/FindAllBattleInfoResponseDocument.java
@@ -34,7 +34,7 @@ public class FindAllBattleInfoResponseDocument extends SuccessMessageResponseDoc
         public LocalDate expireDate;
 
         @Schema(description = "결과", example = "WON")
-        public String result; // WON, LOST, DRAWN, WINNING, LOSING, DRAWING, NOT_STARTED, CANCELED, PENDING
+        public String result; // WON, LOST, DRAWN, WINNING, LOSING, DRAWING
     }
 
     public static class EnemyDoc {

--- a/src/main/java/com/process/clash/application/compete/rival/battle/data/FindAllBattleInfoData.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/data/FindAllBattleInfoData.java
@@ -29,7 +29,7 @@ public class FindAllBattleInfoData {
             Long id,
             Enemy enemy,
             LocalDate expireDate,
-            String result // WON, LOST, DRAWN, WINNING, LOSING, DRAWING, NOT_STARTED, CANCELED, PENDING
+            String result // WON, LOST, DRAWN, WINNING, LOSING, DRAWING
     ) {
         public static BattleInfo of(Long id, Enemy enemy, LocalDate expireDate, String result) {
             return new BattleInfo(id, enemy, expireDate, result);

--- a/src/main/java/com/process/clash/application/compete/rival/battle/port/out/BattleRepositoryPort.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/port/out/BattleRepositoryPort.java
@@ -19,6 +19,5 @@ public interface BattleRepositoryPort {
     void rejectAllActiveBattlesByUserId(Long userId);
     void rejectAllActiveBattlesByRivalId(Long rivalId);
     List<Battle> findExpiredInProgressBattles();
-    List<Battle> findExpiredNotStartedBattles();
     List<Battle> findPendingBattlesByUserId(Long userId);
 }

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/BattleFinishService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/BattleFinishService.java
@@ -32,56 +32,50 @@ public class BattleFinishService {
 
     public void finishExpiredBattles() {
         List<Battle> expiredInProgress = battleRepositoryPort.findExpiredInProgressBattles();
-        List<Battle> expiredNotStarted = battleRepositoryPort.findExpiredNotStartedBattles();
+
+        if (expiredInProgress.isEmpty()) {
+            return;
+        }
 
         List<Battle> battlesToUpdate = new ArrayList<>();
 
-        if (!expiredInProgress.isEmpty()) {
-            // 라이벌 일괄 조회
-            Set<Long> rivalIds = expiredInProgress.stream()
-                    .map(Battle::rivalId)
-                    .collect(Collectors.toSet());
-            Map<Long, Rival> rivalMap = rivalRepositoryPort.findByIdIn(rivalIds).stream()
-                    .collect(Collectors.toMap(Rival::id, r -> r));
+        // 라이벌 일괄 조회
+        Set<Long> rivalIds = expiredInProgress.stream()
+                .map(Battle::rivalId)
+                .collect(Collectors.toSet());
+        Map<Long, Rival> rivalMap = rivalRepositoryPort.findByIdIn(rivalIds).stream()
+                .collect(Collectors.toMap(Rival::id, r -> r));
 
-            // 유저별 배틀 그룹화 후 평균 exp 일괄 조회
-            Map<Long, List<Battle>> battlesByUserId = new HashMap<>();
-            for (Battle battle : expiredInProgress) {
-                Rival rival = rivalMap.get(battle.rivalId());
-                if (rival == null) continue;
-                battlesByUserId.computeIfAbsent(rival.firstUserId(), k -> new ArrayList<>()).add(battle);
-                battlesByUserId.computeIfAbsent(rival.secondUserId(), k -> new ArrayList<>()).add(battle);
-            }
+        // 유저별 배틀 그룹화 후 평균 exp 일괄 조회
+        Map<Long, List<Battle>> battlesByUserId = new HashMap<>();
+        for (Battle battle : expiredInProgress) {
+            Rival rival = rivalMap.get(battle.rivalId());
+            if (rival == null) continue;
+            battlesByUserId.computeIfAbsent(rival.firstUserId(), k -> new ArrayList<>()).add(battle);
+            battlesByUserId.computeIfAbsent(rival.secondUserId(), k -> new ArrayList<>()).add(battle);
+        }
 
-            Map<Long, Map<Long, Double>> avgExpByUserAndBattle = new HashMap<>();
-            for (Map.Entry<Long, List<Battle>> entry : battlesByUserId.entrySet()) {
-                avgExpByUserAndBattle.put(
-                        entry.getKey(),
-                        userExpHistoryRepositoryPort.findAverageExpForBattles(entry.getKey(), entry.getValue())
-                );
-            }
+        Map<Long, Map<Long, Double>> avgExpByUserAndBattle = new HashMap<>();
+        for (Map.Entry<Long, List<Battle>> entry : battlesByUserId.entrySet()) {
+            avgExpByUserAndBattle.put(
+                    entry.getKey(),
+                    userExpHistoryRepositoryPort.findAverageExpForBattles(entry.getKey(), entry.getValue())
+            );
+        }
 
-            for (Battle battle : expiredInProgress) {
-                try {
-                    Rival rival = Optional.ofNullable(rivalMap.get(battle.rivalId()))
-                            .orElseThrow(() -> new IllegalStateException("Rival not found. rivalId=" + battle.rivalId()));
-                    Long winnerId = determineWinner(battle.id(), rival.firstUserId(), rival.secondUserId(), avgExpByUserAndBattle);
-                    battlesToUpdate.add(battle.finishWithWinner(winnerId));
-                } catch (Exception e) {
-                    log.error("배틀 종료 처리 중 오류 발생. battleId={}", battle.id(), e);
-                }
+        for (Battle battle : expiredInProgress) {
+            try {
+                Rival rival = Optional.ofNullable(rivalMap.get(battle.rivalId()))
+                        .orElseThrow(() -> new IllegalStateException("Rival not found. rivalId=" + battle.rivalId()));
+                Long winnerId = determineWinner(battle.id(), rival.firstUserId(), rival.secondUserId(), avgExpByUserAndBattle);
+                battlesToUpdate.add(battle.finishWithWinner(winnerId));
+            } catch (Exception e) {
+                log.error("배틀 종료 처리 중 오류 발생. battleId={}", battle.id(), e);
             }
         }
 
-        expiredNotStarted.stream()
-                .map(Battle::cancel)
-                .forEach(battlesToUpdate::add);
-
-        if (!battlesToUpdate.isEmpty()) {
-            battleRepositoryPort.saveAll(battlesToUpdate);
-        }
-
-        log.info("Expired battles processed. done={}, canceled={}", expiredInProgress.size(), expiredNotStarted.size());
+        battleRepositoryPort.saveAll(battlesToUpdate);
+        log.info("Expired battles processed. done={}", expiredInProgress.size());
     }
 
     /**

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/BattleFinishService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/BattleFinishService.java
@@ -74,8 +74,10 @@ public class BattleFinishService {
             }
         }
 
-        battleRepositoryPort.saveAll(battlesToUpdate);
-        log.info("Expired battles processed. done={}", expiredInProgress.size());
+        if (!battlesToUpdate.isEmpty()) {
+            battleRepositoryPort.saveAll(battlesToUpdate);
+        }
+        log.info("Expired battles processed. done={}", battlesToUpdate.size());
     }
 
     /**

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
@@ -35,7 +35,6 @@ public class FindAllBattleInfoService implements FindAllBattleInfoUseCase {
     private static final String RESULT_WINNING = "WINNING";
     private static final String RESULT_LOSING = "LOSING";
     private static final String RESULT_DRAWING = "DRAWING";
-    private static final String RESULT_NOT_STARTED = "NOT_STARTED";
 
     private final BattleRepositoryPort battleRepositoryPort;
     private final BattleFinishService battleFinishService;
@@ -211,11 +210,6 @@ public class FindAllBattleInfoService implements FindAllBattleInfoUseCase {
             } else {
                 return RESULT_DRAWING;
             }
-        }
-
-        // 시작 전 배틀
-        if (status == BattleStatus.NOT_STARTED) {
-            return RESULT_NOT_STARTED;
         }
 
         throw new IllegalStateException("Unexpected battle status: " + status);

--- a/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
+++ b/src/main/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoService.java
@@ -36,8 +36,6 @@ public class FindAllBattleInfoService implements FindAllBattleInfoUseCase {
     private static final String RESULT_LOSING = "LOSING";
     private static final String RESULT_DRAWING = "DRAWING";
     private static final String RESULT_NOT_STARTED = "NOT_STARTED";
-    private static final String RESULT_CANCELED = "CANCELED";
-    private static final String RESULT_PENDING = "PENDING";
 
     private final BattleRepositoryPort battleRepositoryPort;
     private final BattleFinishService battleFinishService;
@@ -218,11 +216,6 @@ public class FindAllBattleInfoService implements FindAllBattleInfoUseCase {
         // 시작 전 배틀
         if (status == BattleStatus.NOT_STARTED) {
             return RESULT_NOT_STARTED;
-        }
-
-        // 취소된 배틀
-        if (status == BattleStatus.CANCELED) {
-            return RESULT_CANCELED;
         }
 
         throw new IllegalStateException("Unexpected battle status: " + status);

--- a/src/main/java/com/process/clash/domain/rival/battle/enums/BattleStatus.java
+++ b/src/main/java/com/process/clash/domain/rival/battle/enums/BattleStatus.java
@@ -2,7 +2,6 @@ package com.process.clash.domain.rival.battle.enums;
 
 public enum BattleStatus {
     IN_PROGRESS,
-    NOT_STARTED,
     PENDING,
     DONE,
     REJECTED,

--- a/src/main/resources/db/migration/V33__cancel_not_started_battles.sql
+++ b/src/main/resources/db/migration/V33__cancel_not_started_battles.sql
@@ -1,0 +1,5 @@
+-- 배틀 승인 즉시 IN_PROGRESS로 시작되도록 변경함에 따라
+-- 기존에 남아 있는 NOT_STARTED 상태 배틀을 CANCELED로 일괄 전환
+UPDATE battles
+SET battle_status = 'CANCELED'
+WHERE battle_status = 'NOT_STARTED';

--- a/src/test/java/com/process/clash/application/compete/rival/battle/service/BattleFinishServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/battle/service/BattleFinishServiceTest.java
@@ -65,7 +65,6 @@ class BattleFinishServiceTest {
                 RivalLinkingStatus.ACCEPTED, FIRST_USER_ID, SECOND_USER_ID);
 
         when(battleRepositoryPort.findExpiredInProgressBattles()).thenReturn(List.of(inProgressBattle));
-        when(battleRepositoryPort.findExpiredNotStartedBattles()).thenReturn(List.of());
         when(rivalRepositoryPort.findByIdIn(Set.of(RIVAL_ID))).thenReturn(List.of(rival));
         when(userExpHistoryRepositoryPort.findAverageExpForBattles(eq(FIRST_USER_ID), anyList()))
                 .thenReturn(Map.of(1L, 10.0));
@@ -80,58 +79,9 @@ class BattleFinishServiceTest {
     }
 
     @Test
-    @DisplayName("종료 시각이 지난 NOT_STARTED 배틀을 CANCELED로 전환한다")
-    void finishExpiredBattles_transitionsNotStartedToCanceled() {
-        Instant startedAt = Instant.now().minus(8, ChronoUnit.DAYS);
-        Instant endAt = Instant.now().minus(1, ChronoUnit.DAYS);
-        Battle notStartedBattle = new Battle(2L, Instant.now(), Instant.now(),
-                startedAt, endAt, 7, BattleStatus.NOT_STARTED, null, RIVAL_ID, FIRST_USER_ID);
-
-        when(battleRepositoryPort.findExpiredInProgressBattles()).thenReturn(List.of());
-        when(battleRepositoryPort.findExpiredNotStartedBattles()).thenReturn(List.of(notStartedBattle));
-
-        battleFinishService.finishExpiredBattles();
-
-        ArgumentCaptor<List<Battle>> captor = ArgumentCaptor.forClass(List.class);
-        verify(battleRepositoryPort).saveAll(captor.capture());
-        assertThat(captor.getValue()).allMatch(b -> b.battleStatus() == BattleStatus.CANCELED);
-    }
-
-    @Test
-    @DisplayName("IN_PROGRESS와 NOT_STARTED 만료 배틀을 한 번의 saveAll로 처리한다")
-    void finishExpiredBattles_savesAllInSingleCall() {
-        Instant startedAt = Instant.now().minus(8, ChronoUnit.DAYS);
-        Instant endAt = Instant.now().minus(1, ChronoUnit.DAYS);
-        Battle inProgressBattle = new Battle(1L, Instant.now(), Instant.now(),
-                startedAt, endAt, 7, BattleStatus.IN_PROGRESS, null, RIVAL_ID, FIRST_USER_ID);
-        Battle notStartedBattle = new Battle(2L, Instant.now(), Instant.now(),
-                startedAt, endAt, 7, BattleStatus.NOT_STARTED, null, RIVAL_ID, FIRST_USER_ID);
-
-        Rival rival = new Rival(RIVAL_ID, Instant.now(), Instant.now(),
-                RivalLinkingStatus.ACCEPTED, FIRST_USER_ID, SECOND_USER_ID);
-
-        when(battleRepositoryPort.findExpiredInProgressBattles()).thenReturn(List.of(inProgressBattle));
-        when(battleRepositoryPort.findExpiredNotStartedBattles()).thenReturn(List.of(notStartedBattle));
-        when(rivalRepositoryPort.findByIdIn(Set.of(RIVAL_ID))).thenReturn(List.of(rival));
-        when(userExpHistoryRepositoryPort.findAverageExpForBattles(eq(FIRST_USER_ID), anyList()))
-                .thenReturn(Map.of(1L, 10.0));
-        when(userExpHistoryRepositoryPort.findAverageExpForBattles(eq(SECOND_USER_ID), anyList()))
-                .thenReturn(Map.of(1L, 5.0));
-
-        battleFinishService.finishExpiredBattles();
-
-        ArgumentCaptor<List<Battle>> captor = ArgumentCaptor.forClass(List.class);
-        verify(battleRepositoryPort).saveAll(captor.capture());
-        assertThat(captor.getValue()).hasSize(2)
-                .anyMatch(b -> b.battleStatus() == BattleStatus.DONE)
-                .anyMatch(b -> b.battleStatus() == BattleStatus.CANCELED);
-    }
-
-    @Test
     @DisplayName("종료할 배틀이 없으면 saveAll을 호출하지 않는다")
     void finishExpiredBattles_doesNotCallSaveAll_whenNoBattlesToProcess() {
         when(battleRepositoryPort.findExpiredInProgressBattles()).thenReturn(List.of());
-        when(battleRepositoryPort.findExpiredNotStartedBattles()).thenReturn(List.of());
 
         battleFinishService.finishExpiredBattles();
 

--- a/src/test/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoServiceTest.java
@@ -158,16 +158,6 @@ class FindAllBattleInfoServiceTest {
     }
 
     @Test
-    @DisplayName("CANCELED 배틀은 CANCELED를 반환한다")
-    void execute_returnsCanceled_whenCanceled() {
-        stubCommonDependencies(List.of(battle(BattleStatus.CANCELED, null)));
-
-        FindAllBattleInfoData.Result result = findAllBattleInfoService.execute(command());
-
-        assertThat(result.battles().get(0).result()).isEqualTo("CANCELED");
-    }
-
-    @Test
     @DisplayName("상대방 rankTier가 NONE이면 expTier를 tier로 반환한다")
     void execute_returnsEnemyTierAsExpTier_whenRankTierIsNone() {
         stubCommonDependenciesWithEnemy(RankTier.NONE, ExpTier.GOLD,

--- a/src/test/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoServiceTest.java
+++ b/src/test/java/com/process/clash/application/compete/rival/battle/service/FindAllBattleInfoServiceTest.java
@@ -148,16 +148,6 @@ class FindAllBattleInfoServiceTest {
     }
 
     @Test
-    @DisplayName("NOT_STARTED 배틀은 NOT_STARTED를 반환한다")
-    void execute_returnsNotStarted_whenNotStarted() {
-        stubCommonDependencies(List.of(battle(BattleStatus.NOT_STARTED, null)));
-
-        FindAllBattleInfoData.Result result = findAllBattleInfoService.execute(command());
-
-        assertThat(result.battles().get(0).result()).isEqualTo("NOT_STARTED");
-    }
-
-    @Test
     @DisplayName("상대방 rankTier가 NONE이면 expTier를 tier로 반환한다")
     void execute_returnsEnemyTierAsExpTier_whenRankTierIsNone() {
         stubCommonDependenciesWithEnemy(RankTier.NONE, ExpTier.GOLD,


### PR DESCRIPTION
## 변경사항
  - 배틀 목록 조회(`findByUserIdWithOutRejected`) 쿼리에서 `CANCELED` 상태 제외                                                                                                      
  - 배틀 승인 즉시 `IN_PROGRESS`로 시작됨에 따라 `NOT_STARTED` 상태 전면 제거
    - `BattleStatus.NOT_STARTED` 열거값 삭제                                                                                                                                         
    - `findExpiredNotStartedBattles()` 관련 쿼리 / 포트 / 어댑터 삭제                                                                                                              
    - `BattleFinishService`의 NOT_STARTED 만료 처리 로직 삭제
    - `FindAllBattleInfoService`의 NOT_STARTED 결과 분기 및 상수 삭제
    - Swagger 문서 오기재("NOT_STARTED 상태가 됨") 수정

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #659 

## 추가 컨텍스트
  `NOT_STARTED`는 "승인 후 시작일까지 대기" 플로우에서 사용되던 상태였으나,
  승인 즉시 배틀이 시작되는 구조로 변경되면서 실제로 이 상태로 진입하는 코드 경로가 없어졌습니다.
  DB에 기존 `NOT_STARTED` 레코드가 남아 있을 수 있으므로 필요 시 데이터 마이그레이션을 검토해주세요.