### PR TITLE
fix: analyze my exp/#670

### DIFF
--- a/src/main/java/com/process/clash/adapter/persistence/github/GitHubDailyStatsJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/github/GitHubDailyStatsJpaRepository.java
@@ -78,7 +78,7 @@ public interface GitHubDailyStatsJpaRepository extends JpaRepository<GitHubDaily
             SELECT
                 user_id,
                 cast(date_trunc('month', study_date) as date) + (floor((extract(day from study_date) - 1) / 7) * 7)::int AS week_start,
-                AVG(commit_count + pr_count + review_count + issue_count) AS point,
+                SUM(commit_count + pr_count + review_count + issue_count) AS point,
                 ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY cast(date_trunc('month', study_date) as date) + (floor((extract(day from study_date) - 1) / 7) * 7)::int DESC) as rn
             FROM github_daily_stats
             WHERE user_id IN (:userIds)
@@ -105,7 +105,7 @@ public interface GitHubDailyStatsJpaRepository extends JpaRepository<GitHubDaily
             SELECT
                 user_id,
                 cast(date_trunc('month', study_date) as date) AS month_start,
-                AVG(commit_count + pr_count + review_count + issue_count) AS point,
+                SUM(commit_count + pr_count + review_count + issue_count) AS point,
                 ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY date_trunc('month', study_date) DESC) as rn
             FROM github_daily_stats
             WHERE user_id IN (:userIds)

--- a/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
@@ -38,7 +38,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
             SELECT
                 fk_user_id,
                 cast(date_trunc('day', date) as date) AS day_date,
-                AVG(earn_exp) AS point,
+                SUM(earn_exp) AS point,
                 ROW_NUMBER() OVER (PARTITION BY fk_user_id ORDER BY date_trunc('day', date) DESC) as rn
             FROM user_exp_history
             WHERE fk_user_id IN (:userIds)
@@ -67,7 +67,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
             SELECT
                 fk_user_id,
                 cast(date_trunc('month', date) as date) + (floor((extract(day from date) - 1) / 7) * 7)::int AS week_start,
-                AVG(earn_exp) AS point,
+                SUM(earn_exp) AS point,
                 ROW_NUMBER() OVER (PARTITION BY fk_user_id ORDER BY cast(date_trunc('month', date) as date) + (floor((extract(day from date) - 1) / 7) * 7)::int DESC) as rn
             FROM user_exp_history
             WHERE fk_user_id IN (:userIds)
@@ -96,7 +96,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
             SELECT
                 fk_user_id,
                 cast(date_trunc('month', date) as date) AS month_start,
-                AVG(earn_exp) AS point,
+                SUM(earn_exp) AS point,
                 ROW_NUMBER() OVER (PARTITION BY fk_user_id ORDER BY date_trunc('month', date) DESC) as rn
             FROM user_exp_history
             WHERE fk_user_id IN (:userIds)

--- a/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
+++ b/src/main/java/com/process/clash/adapter/persistence/user/userexphistory/UserExpHistoryJpaRepository.java
@@ -44,6 +44,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
             WHERE fk_user_id IN (:userIds)
               AND date >= date_trunc('day', CAST(:startDate AS date))
               AND date <= :endDate
+              AND acting_category <> 'SEASON_RESET'
             GROUP BY fk_user_id, date_trunc('day', date)
         ) subquery
         WHERE rn <= 10
@@ -73,6 +74,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
             WHERE fk_user_id IN (:userIds)
               AND date >= :startDate
               AND date <= :endDate
+              AND acting_category <> 'SEASON_RESET'
             GROUP BY fk_user_id, cast(date_trunc('month', date) as date) + (floor((extract(day from date) - 1) / 7) * 7)::int
         ) subquery
         WHERE rn <= 10
@@ -102,6 +104,7 @@ public interface UserExpHistoryJpaRepository extends JpaRepository<UserExpHistor
             WHERE fk_user_id IN (:userIds)
               AND date >= date_trunc('month', CAST(:startDate AS date))
               AND date <= :endDate
+              AND acting_category <> 'SEASON_RESET'
             GROUP BY fk_user_id, date_trunc('month', date)
         ) subquery
         WHERE rn <= 10


### PR DESCRIPTION
## 변경사항
  - EXP/GitHub 기간별 통계 집계 함수 AVG → SUM 으로 수정                                                                                                                             
    - UserExpHistoryJpaRepository: findDailyDataByUserIds, findWeeklyDataByUserIds, findMonthlyDataByUserIds
    - GitHubDailyStatsJpaRepository: findWeeklyContributionsByUserIds, findMonthlyContributionsByUserIds 

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #670 

## 추가 컨텍스트
  user_exp_history는 동일 날짜에 acting_category별로 여러 행이 존재하므로,
  AVG 집계 시 카테고리 수만큼 나눠진 값이 반환되어 실제 값의 절반이 표시되는 버그 발생.
  SUM으로 변경하여 기간 내 실제 총 획득 exp/기여도를 반환하도록 수정.