### PR TITLE
feat: global notice socket/#681

### DIFF
--- a/src/main/java/com/process/clash/adapter/realtime/socketio/SocketIoBroadcastAdapter.java
+++ b/src/main/java/com/process/clash/adapter/realtime/socketio/SocketIoBroadcastAdapter.java
@@ -32,4 +32,13 @@ public class SocketIoBroadcastAdapter implements BroadcastRefetchPort {
             operations.sendEvent(EVENT_CHANGE, payload);
         }
     }
+
+    @Override
+    public void broadcastRefetchToAll(RefetchNotice notice) {
+        if (notice == null) {
+            return;
+        }
+        ChangePayload payload = ChangePayload.from(notice);
+        socketIOServer.getBroadcastOperations().sendEvent(EVENT_CHANGE, payload);
+    }
 }

--- a/src/main/java/com/process/clash/application/announcement/admin/service/CreateAnnouncementAdminService.java
+++ b/src/main/java/com/process/clash/application/announcement/admin/service/CreateAnnouncementAdminService.java
@@ -3,6 +3,7 @@ package com.process.clash.application.announcement.admin.service;
 import com.process.clash.application.announcement.admin.data.CreateAnnouncementAdminData;
 import com.process.clash.application.announcement.admin.port.in.CreateAnnouncementAdminUseCase;
 import com.process.clash.application.announcement.port.out.AnnouncementRepositoryPort;
+import com.process.clash.application.announcement.realtime.AnnouncementRefetchNotifier;
 import com.process.clash.application.common.policy.CheckAdminPolicy;
 import com.process.clash.domain.announcement.entity.Announcement;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +17,14 @@ public class CreateAnnouncementAdminService implements CreateAnnouncementAdminUs
 
     private final AnnouncementRepositoryPort announcementRepositoryPort;
     private final CheckAdminPolicy checkAdminPolicy;
+    private final AnnouncementRefetchNotifier announcementRefetchNotifier;
 
     @Override
     public CreateAnnouncementAdminData.Result execute(CreateAnnouncementAdminData.Command command) {
         checkAdminPolicy.check(command.actor());
 
         Announcement saved = announcementRepositoryPort.save(command.toDomain());
+        announcementRefetchNotifier.notifyAnnouncementChanged();
         return CreateAnnouncementAdminData.Result.from(saved);
     }
 }

--- a/src/main/java/com/process/clash/application/announcement/admin/service/DeleteAnnouncementAdminService.java
+++ b/src/main/java/com/process/clash/application/announcement/admin/service/DeleteAnnouncementAdminService.java
@@ -4,6 +4,7 @@ import com.process.clash.application.announcement.admin.data.DeleteAnnouncementA
 import com.process.clash.application.announcement.admin.port.in.DeleteAnnouncementAdminUseCase;
 import com.process.clash.application.announcement.exception.exception.notfound.AnnouncementNotFoundException;
 import com.process.clash.application.announcement.port.out.AnnouncementRepositoryPort;
+import com.process.clash.application.announcement.realtime.AnnouncementRefetchNotifier;
 import com.process.clash.application.common.policy.CheckAdminPolicy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ public class DeleteAnnouncementAdminService implements DeleteAnnouncementAdminUs
 
     private final AnnouncementRepositoryPort announcementRepositoryPort;
     private final CheckAdminPolicy checkAdminPolicy;
+    private final AnnouncementRefetchNotifier announcementRefetchNotifier;
 
     @Override
     public void execute(DeleteAnnouncementAdminData.Command command) {
@@ -26,5 +28,6 @@ public class DeleteAnnouncementAdminService implements DeleteAnnouncementAdminUs
         }
 
         announcementRepositoryPort.deleteById(command.id());
+        announcementRefetchNotifier.notifyAnnouncementChanged();
     }
 }

--- a/src/main/java/com/process/clash/application/announcement/admin/service/UpdateAnnouncementAdminService.java
+++ b/src/main/java/com/process/clash/application/announcement/admin/service/UpdateAnnouncementAdminService.java
@@ -4,6 +4,7 @@ import com.process.clash.application.announcement.admin.data.UpdateAnnouncementA
 import com.process.clash.application.announcement.admin.port.in.UpdateAnnouncementAdminUseCase;
 import com.process.clash.application.announcement.exception.exception.notfound.AnnouncementNotFoundException;
 import com.process.clash.application.announcement.port.out.AnnouncementRepositoryPort;
+import com.process.clash.application.announcement.realtime.AnnouncementRefetchNotifier;
 import com.process.clash.application.common.policy.CheckAdminPolicy;
 import com.process.clash.domain.announcement.entity.Announcement;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class UpdateAnnouncementAdminService implements UpdateAnnouncementAdminUs
 
     private final AnnouncementRepositoryPort announcementRepositoryPort;
     private final CheckAdminPolicy checkAdminPolicy;
+    private final AnnouncementRefetchNotifier announcementRefetchNotifier;
 
     @Override
     public UpdateAnnouncementAdminData.Result execute(UpdateAnnouncementAdminData.Command command) {
@@ -38,6 +40,7 @@ public class UpdateAnnouncementAdminService implements UpdateAnnouncementAdminUs
         );
 
         Announcement saved = announcementRepositoryPort.save(updated);
+        announcementRefetchNotifier.notifyAnnouncementChanged();
         return UpdateAnnouncementAdminData.Result.from(saved);
     }
 }

--- a/src/main/java/com/process/clash/application/announcement/realtime/AnnouncementRefetchNotifier.java
+++ b/src/main/java/com/process/clash/application/announcement/realtime/AnnouncementRefetchNotifier.java
@@ -1,0 +1,19 @@
+package com.process.clash.application.announcement.realtime;
+
+import com.process.clash.application.realtime.data.ChangeDomain;
+import com.process.clash.application.realtime.data.ChangeType;
+import com.process.clash.application.realtime.data.RefetchNotice;
+import com.process.clash.application.realtime.service.RefetchEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnnouncementRefetchNotifier {
+
+    private final RefetchEventPublisher refetchEventPublisher;
+
+    public void notifyAnnouncementChanged() {
+        refetchEventPublisher.publishToAll(RefetchNotice.of(ChangeDomain.ANNOUNCEMENT, ChangeType.DATA_CHANGED));
+    }
+}

--- a/src/main/java/com/process/clash/application/realtime/data/ChangeDomain.java
+++ b/src/main/java/com/process/clash/application/realtime/data/ChangeDomain.java
@@ -5,5 +5,6 @@ public enum ChangeDomain {
     COMPETE,
     USER,
     RECORD,
-    ATTENDANCE
+    ATTENDANCE,
+    ANNOUNCEMENT
 }

--- a/src/main/java/com/process/clash/application/realtime/port/out/BroadcastRefetchPort.java
+++ b/src/main/java/com/process/clash/application/realtime/port/out/BroadcastRefetchPort.java
@@ -5,4 +5,5 @@ import java.util.Collection;
 
 public interface BroadcastRefetchPort {
     void broadcastRefetchToUsers(RefetchNotice notice, Collection<Long> userIds);
+    void broadcastRefetchToAll(RefetchNotice notice);
 }

--- a/src/main/java/com/process/clash/application/realtime/service/RefetchEventListener.java
+++ b/src/main/java/com/process/clash/application/realtime/service/RefetchEventListener.java
@@ -16,10 +16,14 @@ public class RefetchEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void onRefetchEvent(RefetchEvent event) {
-        if (event == null || event.notice() == null || event.userIds() == null) {
+        if (event == null || event.notice() == null) {
             return;
         }
         Collection<Long> userIds = event.userIds();
+        if (userIds == null) {
+            broadcastRefetchPort.broadcastRefetchToAll(event.notice());
+            return;
+        }
         if (userIds.isEmpty()) {
             return;
         }

--- a/src/main/java/com/process/clash/application/realtime/service/RefetchEventPublisher.java
+++ b/src/main/java/com/process/clash/application/realtime/service/RefetchEventPublisher.java
@@ -30,4 +30,11 @@ public class RefetchEventPublisher {
         }
         applicationEventPublisher.publishEvent(new RefetchEvent(notice, deduped));
     }
+
+    public void publishToAll(RefetchNotice notice) {
+        if (notice == null) {
+            return;
+        }
+        applicationEventPublisher.publishEvent(new RefetchEvent(notice, null));
+    }
 }

--- a/src/test/java/com/process/clash/application/announcement/admin/service/CreateAnnouncementAdminServiceTest.java
+++ b/src/test/java/com/process/clash/application/announcement/admin/service/CreateAnnouncementAdminServiceTest.java
@@ -2,6 +2,7 @@ package com.process.clash.application.announcement.admin.service;
 
 import com.process.clash.application.announcement.admin.data.CreateAnnouncementAdminData;
 import com.process.clash.application.announcement.port.out.AnnouncementRepositoryPort;
+import com.process.clash.application.announcement.realtime.AnnouncementRefetchNotifier;
 import com.process.clash.application.common.actor.Actor;
 import com.process.clash.application.common.policy.CheckAdminPolicy;
 import com.process.clash.application.user.user.exception.exception.forbidden.RequiredAdminRoleException;
@@ -30,11 +31,14 @@ class CreateAnnouncementAdminServiceTest {
     @Mock
     private CheckAdminPolicy checkAdminPolicy;
 
+    @Mock
+    private AnnouncementRefetchNotifier announcementRefetchNotifier;
+
     private CreateAnnouncementAdminService service;
 
     @BeforeEach
     void setUp() {
-        service = new CreateAnnouncementAdminService(announcementRepositoryPort, checkAdminPolicy);
+        service = new CreateAnnouncementAdminService(announcementRepositoryPort, checkAdminPolicy, announcementRefetchNotifier);
     }
 
     @Test

--- a/src/test/java/com/process/clash/application/announcement/admin/service/DeleteAnnouncementAdminServiceTest.java
+++ b/src/test/java/com/process/clash/application/announcement/admin/service/DeleteAnnouncementAdminServiceTest.java
@@ -3,6 +3,7 @@ package com.process.clash.application.announcement.admin.service;
 import com.process.clash.application.announcement.admin.data.DeleteAnnouncementAdminData;
 import com.process.clash.application.announcement.exception.exception.notfound.AnnouncementNotFoundException;
 import com.process.clash.application.announcement.port.out.AnnouncementRepositoryPort;
+import com.process.clash.application.announcement.realtime.AnnouncementRefetchNotifier;
 import com.process.clash.application.common.actor.Actor;
 import com.process.clash.application.common.policy.CheckAdminPolicy;
 import com.process.clash.application.user.user.exception.exception.forbidden.RequiredAdminRoleException;
@@ -30,11 +31,14 @@ class DeleteAnnouncementAdminServiceTest {
     @Mock
     private CheckAdminPolicy checkAdminPolicy;
 
+    @Mock
+    private AnnouncementRefetchNotifier announcementRefetchNotifier;
+
     private DeleteAnnouncementAdminService service;
 
     @BeforeEach
     void setUp() {
-        service = new DeleteAnnouncementAdminService(announcementRepositoryPort, checkAdminPolicy);
+        service = new DeleteAnnouncementAdminService(announcementRepositoryPort, checkAdminPolicy, announcementRefetchNotifier);
     }
 
     @Test

--- a/src/test/java/com/process/clash/application/announcement/admin/service/UpdateAnnouncementAdminServiceTest.java
+++ b/src/test/java/com/process/clash/application/announcement/admin/service/UpdateAnnouncementAdminServiceTest.java
@@ -3,6 +3,7 @@ package com.process.clash.application.announcement.admin.service;
 import com.process.clash.application.announcement.admin.data.UpdateAnnouncementAdminData;
 import com.process.clash.application.announcement.exception.exception.notfound.AnnouncementNotFoundException;
 import com.process.clash.application.announcement.port.out.AnnouncementRepositoryPort;
+import com.process.clash.application.announcement.realtime.AnnouncementRefetchNotifier;
 import com.process.clash.application.common.policy.CheckAdminPolicy;
 import com.process.clash.application.user.user.exception.exception.forbidden.RequiredAdminRoleException;
 import com.process.clash.domain.announcement.entity.Announcement;
@@ -32,11 +33,14 @@ class UpdateAnnouncementAdminServiceTest {
     @Mock
     private CheckAdminPolicy checkAdminPolicy;
 
+    @Mock
+    private AnnouncementRefetchNotifier announcementRefetchNotifier;
+
     private UpdateAnnouncementAdminService service;
 
     @BeforeEach
     void setUp() {
-        service = new UpdateAnnouncementAdminService(announcementRepositoryPort, checkAdminPolicy);
+        service = new UpdateAnnouncementAdminService(announcementRepositoryPort, checkAdminPolicy, announcementRefetchNotifier);
     }
 
     @Test


### PR DESCRIPTION
## 변경사항

- 전체공지 등록/수정/삭제 시 소켓으로 접속 중인 모든 유저에게 브로드캐스트
- `ChangeDomain.ANNOUNCEMENT` 추가
- `BroadcastRefetchPort.broadcastRefetchToAll()` 및 `RefetchEventPublisher.publishToAll()` 추가

## 관련 이슈

Closes #681

## 추가 컨텍스트

기존 소켓 브로드캐스트는 특정 유저 ID 목록 대상이었으나, 전체공지는 불특정 다수에게 전송해야 하므로 `socketIOServer.getBroadcastOperations()`를 활용한 전체 브로드캐스트 경로를 별도로 추가함
