### PR TITLE
fix: sync exp/#685

### DIFF
--- a/src/main/resources/db/migration/V38__sync_user_exp_with_history.sql
+++ b/src/main/resources/db/migration/V38__sync_user_exp_with_history.sql
@@ -1,0 +1,21 @@
+-- 베타 시즌 종료 후 일괄 exp 회수로 인해 users.total_exp가
+-- user_exp_history 누적 합계와 불일치하는 상태를 동기화한다.
+-- earn_exp 합계가 음수가 되는 경우(회수 이후 추가 획득 없는 유저)는 0으로 처리한다.
+
+UPDATE users u
+SET total_exp = GREATEST(0, COALESCE(
+    (SELECT SUM(ueh.earn_exp)
+     FROM user_exp_history ueh
+     WHERE ueh.fk_user_id = u.id),
+    0
+));
+
+-- 보정된 total_exp 기준으로 current_exp_tier 재계산
+UPDATE users
+SET current_exp_tier = CASE
+    WHEN total_exp >= 100000 THEN 'DIAMOND'
+    WHEN total_exp >= 30000 THEN 'GOLD'
+    WHEN total_exp >= 10000 THEN 'SILVER'
+    WHEN total_exp >= 1000  THEN 'BRONZE'
+    ELSE 'UNRANKED'
+END;


### PR DESCRIPTION
## 변경사항
  - 베타 시즌 exp 일괄 회수 후 users.total_exp와 user_exp_history 누적 합계가 불일치하는 데이터를 동기화하는 Flyway 마이그레이션 스크립트(V38) 추가                                  
  - 각 유저의 total_exp를 user_exp_history.earn_exp 전체 합산값으로 보정 (음수 방지를 위해 GREATEST(0, ...) 적용)                                                                    
  - 보정된 total_exp 기준으로 current_exp_tier 재계산

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #685 

## 추가 컨텍스트
  - SEASON_RESET 카테고리의 히스토리 항목(-currentExp)이 이미 기록되어 있어, SUM(earn_exp)가 실제 잔여 exp를 정확히 반영함
  - 히스토리 레코드가 전혀 없는 유저는 COALESCE(..., 0)으로 0 처리
  - exp 티어 기준: UNRANKED / BRONZE(1,000+) / SILVER(10,000+) / GOLD(30,000+) / DIAMOND(100,000+)